### PR TITLE
Fix comma splice in VMware vSphere installation

### DIFF
--- a/content/en/docs/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
+++ b/content/en/docs/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
@@ -36,12 +36,12 @@ This tutorial creates 8 virtual machines of **CentOS Linux release 7.6.1810 (Cor
 |10.10.71.75|node1|worker|
 |10.10.71.76|node2|worker|
 |10.10.71.79|node3|worker|
-|10.10.71.67|vip|vip(No need to create a VM)|
+|10.10.71.67|vip|vip (No need to create a VM)|
 |10.10.71.77|lb-0|lb (Keepalived + HAProxy)|
 |10.10.71.66|lb-1|lb (Keepalived + HAProxy)|
 
 {{< notice warning >}}
-The `vip` is a virtual IP, there is no need to create a virtual machine, so only 8 virtual machines need to be created.
+You do not need to create a virtual machine for `vip` (i.e. Virtual IP) above, so only 8 virtual machines need to be created.
 {{</ notice >}}
 
 Create virtual machines in the VMware Host Client. You can follow the New Virtual Machine wizard to create a virtual machine to place in the VMware Host Client inventory.


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

Do not use a comma to connect two complete sentences in English, also known as **comma splice**, which is grammatically incorrect.