### PR TITLE
Update previous page UI

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -60,8 +60,8 @@
   translation: Last updated
 - id: What’s on this Page
   translation: What’s on this Page
-- id: Last
-  translation: Last
+- id: Previous
+  translation: Previous
 - id: Next
   translation: Next
 - id: edit

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -60,7 +60,7 @@
   translation: 最新更新
 - id: What’s on this Page
   translation: 页面内容
-- id: Last
+- id: Previous
   translation: 上一篇
 - id: Next
   translation: 下一篇

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -124,8 +124,8 @@
                     {{ with .Next }}
                     <!-- {{ if .IsDescendant (.GetPage "/docs")}} -->
                         <a class="last" href="{{.RelPermalink}}">
-                            <img src="/images/docs/last.svg" alt="{{ i18n "Last" }}">
-                            {{ i18n "Last" }}
+                            <img src="/images/docs/last.svg" alt="{{ i18n "Previous" }}">
+                            {{ i18n "Previous" }}
                             <span>: {{.LinkTitle}}</span>
                         </a>
                     <!-- {{ end }} -->


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

The more common way of saying "上一页" should be "previous page", not "last page". For example, this is from AWS Doc:
![截屏2020-10-14下午2 26 12](https://user-images.githubusercontent.com/65327072/95951680-72f46780-0e29-11eb-898f-c4944d9d2998.png)
