### PR TITLE
remove outdated cmd for storage installation

### DIFF
--- a/content/en/docs/installing-on-linux/introduction/multioverview.md
+++ b/content/en/docs/installing-on-linux/introduction/multioverview.md
@@ -153,18 +153,6 @@ Here are some examples for your reference:
 ./kk create config [-f ~/myfolder/abc.yaml]
 ```
 
-- You can customize persistent storage plugins (e.g. NFS Client, Ceph RBD, and GlusterFS) in `config-sample.yaml`.
-
-```bash
-./kk create config --with-storage localVolume
-```
-
-{{< notice note >}}
-
-KubeKey will install [OpenEBS](https://openebs.io/) to provision [LocalPV](https://kubernetes.io/docs/concepts/storage/volumes/#local) for development and testing environment by default, which is convenient for new users. In this example of multi-node installation, the default storage class (local volume) is used. For production, please use NFS/Ceph/GlusterFS/CSI or commercial products as persistent storage solutions. You need to specify them under `addons` of `config-sample.yaml`. See [Persistent Storage Configuration](../storage-configuration) for more details.
-
-{{</ notice >}}
-
 - You can specify a KubeSphere version that you want to install (e.g. `--with-kubesphere v3.0.0`).
 
 ```bash
@@ -232,6 +220,16 @@ hosts:
 
 - You can enable the multi-cluster feature by editing the configuration file. For more information, see Multi-cluster Management.
 - You can also select the components you want to install. For more information, see [Enable Pluggable Components](../../../pluggable-components/). For an example of a complete config-sample.yaml file, see [this file](https://github.com/kubesphere/kubekey/blob/master/docs/config-example.md).
+
+{{</ notice >}}
+
+#### addons
+
+You can customize persistent storage plugins (e.g. NFS Client, Ceph RBD, and GlusterFS) by specifying storage under the field `addons` in `config-sample.yaml`. For more information, see [Persistent Storage Configuration](../storage-configuration).
+
+{{< notice note >}}
+
+KubeKey will install [OpenEBS](https://openebs.io/) to provision [LocalPV](https://kubernetes.io/docs/concepts/storage/volumes/#local) for development and testing environment by default, which is convenient for new users. In this example of multi-node installation, the default storage class (local volume) is used. For production, please use NFS/Ceph/GlusterFS/CSI or commercial products as persistent storage solutions.
 
 {{</ notice >}}
 

--- a/content/zh/docs/installing-on-linux/introduction/multioverview.md
+++ b/content/zh/docs/installing-on-linux/introduction/multioverview.md
@@ -56,8 +56,24 @@ The path `/var/lib/docker` is mainly used to store the container data, and will 
 - All nodes must be accessible through `SSH`.
 - Time synchronization for all nodes.
 - `sudo`/`curl`/`openssl` should be used in all nodes.
-- `ebtables`/`socat`/`ipset`/`conntrack` should be installed in all nodes.
 - `docker` can be installed by yourself or by KubeKey.
+
+{{< notice note >}}
+
+`docker` must be installed in advance if you want to deploy KubeSphere in an offline environment.
+
+{{</ notice >}} 
+
+### Dependency Requirements
+
+KubeKey can install Kubernetes and KubeSphere together. The dependency that needs to be installed may be different based on the Kubernetes version to be installed. You can refer to the list below to see if you need to install relevant dependencies on your node in advance. 
+
+| Dependency  | Kubernetes Version ≥ 1.18 | Kubernetes Version < 1.18 |
+| ----------- | ------------------------- | ------------------------- |
+| `socat`     | Required                  | Optional but recommended  |
+| `conntrack` | Required                  | Optional but recommended  |
+| `ebtables`  | Optional but recommended  | Optional but recommended  |
+| `ipset`     | Optional but recommended  | Optional but recommended  |
 
 ### Network and DNS Requirements
 
@@ -105,7 +121,7 @@ wget https://github.com/kubesphere/kubekey/releases/download/v1.0.0/kubekey-v1.0
 
 {{</ tabs >}}
 
-Grant the execution right to `kk`:
+Make `kk` executable:
 
 ```bash
 chmod +x kk
@@ -136,18 +152,6 @@ Here are some examples for your reference:
 ```bash
 ./kk create config [-f ~/myfolder/abc.yaml]
 ```
-
-- You can customize persistent storage plugins (e.g. NFS Client, Ceph RBD, and GlusterFS) in `config-sample.yaml`.
-
-```bash
-./kk create config --with-storage localVolume
-```
-
-{{< notice note >}}
-
-KubeKey will install [OpenEBS](https://openebs.io/) to provision [LocalPV](https://kubernetes.io/docs/concepts/storage/volumes/#local) for development and testing environment by default, which is convenient for new users. In this example of multi-node installation, the default storage class (local volume) is used. For production, please use NFS/Ceph/GlusterFS/CSI or commercial products as persistent storage solutions. You need to specify them under `addons` of `config-sample.yaml`. See [Persistent Storage Configuration](../storage-configuration) for more details.
-
-{{</ notice >}}
 
 - You can specify a KubeSphere version that you want to install (e.g. `--with-kubesphere v3.0.0`).
 
@@ -216,6 +220,16 @@ hosts:
 
 - You can enable the multi-cluster feature by editing the configuration file. For more information, see Multi-cluster Management.
 - You can also select the components you want to install. For more information, see [Enable Pluggable Components](../../../pluggable-components/). For an example of a complete config-sample.yaml file, see [this file](https://github.com/kubesphere/kubekey/blob/master/docs/config-example.md).
+
+{{</ notice >}}
+
+#### addons
+
+You can customize persistent storage plugins (e.g. NFS Client, Ceph RBD, and GlusterFS) by specifying storage under the field `addons` in `config-sample.yaml`. For more information, see [Persistent Storage Configuration](../storage-configuration).
+
+{{< notice note >}}
+
+KubeKey will install [OpenEBS](https://openebs.io/) to provision [LocalPV](https://kubernetes.io/docs/concepts/storage/volumes/#local) for development and testing environment by default, which is convenient for new users. In this example of multi-node installation, the default storage class (local volume) is used. For production, please use NFS/Ceph/GlusterFS/CSI or commercial products as persistent storage solutions.
 
 {{</ notice >}}
 


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

The command `./kk create config --with-storage localVolume` is no longer applicable as storage can be set under `addons` now.