### PR TITLE
fix containerd still uses "k8s.gcr.io/pause"

### DIFF
--- a/content/en/blogs/dockershim-out-of-kubernetes.md
+++ b/content/en/blogs/dockershim-out-of-kubernetes.md
@@ -93,6 +93,8 @@ As KubeSphere supports any implementation of the Kubernetes CRI, you can easily 
    ```bash
    systemctl enable containerd && systemctl restart containerd
    ```
+   
+> If `containerd config dump |grep sandbox_image` still shows `k8s.gcr.io/pause:xxx`, please add `version = 2` to the beginning of `/etc/containerd/config.toml` and run `systemctl restart containerd`.
 
 4. Install crictl.
 

--- a/content/zh/blogs/dockershim-out-of-kubernetes.md
+++ b/content/zh/blogs/dockershim-out-of-kubernetes.md
@@ -91,6 +91,8 @@ EOF
 $ systemctl enable containerd && systemctl restart containerd
 ```
 
+> 如果`containerd config dump |grep sandbox_image`仍是显示`k8s.gcr.io/pause:xxx`，请将`version = 2`添加到`/etc/containerd/config.toml`开头并执行`systemctl restart containerd`。
+
 4. 安装 crictl。
 
 ```shell


### PR DESCRIPTION
fix [kk cannot create cluster with containerd #652](https://github.com/kubesphere/kubekey/issues/652)