### PR TITLE
fix: port type is int in config-sample.yaml

### DIFF
--- a/content/zh/docs/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
+++ b/content/zh/docs/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
@@ -287,7 +287,7 @@ spec:
   controlPlaneEndpoint:
     domain: lb.kubesphere.local
     address: ""                    
-    port: "6443"
+    port: 6443
 ```
 执行以下命令使用自定义的配置文件创建集群：
 


### PR DESCRIPTION
it raises an error when the port type is a string

![image](https://user-images.githubusercontent.com/13731831/138596774-85e0c027-916d-4689-b9fe-075dce9188a9.png)
