### PR TITLE
Disable the topographer extension.

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -3,12 +3,15 @@ baseURL = "https://kubesphere-v3.netlify.app"
 enableRobotsTXT = true
 
 [markup]
+  [markup.goldmark.extensions]
+    typographer = false
   [markup.tableOfContents]
     endLevel = 3
     ordered = false
     startLevel = 2
   [markup.goldmark.renderer]
     unsafe= true
+
 
 [Taxonomies]
 
@@ -33,6 +36,7 @@ facebookLink = "https://www.facebook.com/kubesphere"
 twitterLink = "https://twitter.com/KubeSphere"
 mediumLink = "https://itnext.io/@kubesphere"
 linkedinLink = "https://www.linkedin.com/company/kubesphere/"
+
 
 [languages.en]
 contentDir = "content/en"


### PR DESCRIPTION
Signed-off-by: Patrick-LuoYu <patrickluo@yunify.com>
The topographer extension of Hugo automatically replaces straight quotes with curly quotes, which is undesired.
The following is an example:
![image](https://user-images.githubusercontent.com/76198553/141046546-3ce4255a-3323-4dac-902b-d1088c5ba0f6.png)
![image](https://user-images.githubusercontent.com/76198553/141046687-1f0c6a32-785e-493e-b47f-4b4a8667b40b.png)
This PR fixes this problem by disabling the topographer extension.