### PR TITLE
Using kubectl to replace kubernetesDeploy in the Pipeline CD examples

### DIFF
--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -138,7 +138,7 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
                     credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
                     variable: 'KUBECONFIG')
                     ]) {
-                    sh 'envsubst < devops-go-sample/deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
+                    sh 'envsubst < deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
                 }
              }
            }

--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -105,7 +105,7 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
        stages {
            stage ('checkout scm') {
                steps {
-                   // Please avoid commit your test changes to this repository
+                   // Please avoid committing your test changes to this repository
                    git branch: 'master', url: "https://github.com/kubesphere/devops-maven-sample.git"
                }
            }

--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -57,8 +57,8 @@ The Pod labeled `maven` uses the docker-in-docker network to run the pipeline. N
 ### Prepare for the Maven project
 
 - Ensure you build the Maven project successfully on the development device.
-- Add the Dockerfile to the project repository to build the image. For more information, refer to <https://github.com/kubesphere/devops-java-sample/blob/master/Dockerfile-online>.
-- Add the YAML file to the project repository to deploy the workload. For more information, refer to <https://github.com/kubesphere/devops-java-sample/tree/master/deploy/dev-ol>. If there are different environments, you need to prepare multiple deployment files.
+- Add the Dockerfile to the project repository to build the image. For more information, refer to <https://github.com/kubesphere/devops-maven-sample/blob/master/Dockerfile-online>.
+- Add the YAML file to the project repository to deploy the workload. For more information, refer to <https://github.com/kubesphere/devops-maven-sample/tree/master/deploy/dev-ol>. If there are different environments, you need to prepare multiple deployment files.
 
 ### Create credentials
 
@@ -97,7 +97,7 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
            REGISTRY = 'docker.io'
            // need to replace by yourself dockerhub namespace
            DOCKERHUB_NAMESPACE = 'Docker Hub Namespace'
-           APP_NAME = 'devops-java-sample'
+           APP_NAME = 'devops-maven-sample'
            BRANCH_NAME = 'dev'
            PROJECT_NAME = 'kubesphere-sample-dev'
        }

--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -121,7 +121,7 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
            stage ('build & push') {
                steps {
                    container ('maven') {
-                       sh 'mvn -o -Dmaven.test.skip=true clean package'
+                       sh 'mvn -Dmaven.test.skip=true clean package'
                        sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
                        withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'

--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -83,11 +83,9 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
 
    ```groovy
    pipeline {
-     agent {
-       node {
-         label 'maven'
+       agent {
+           label 'maven'
        }
-     }
    
        parameters {
            string(name:'TAG_NAME',defaultValue: '',description:'')
@@ -101,19 +99,21 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
            DOCKERHUB_NAMESPACE = 'Docker Hub Namespace'
            APP_NAME = 'devops-java-sample'
            BRANCH_NAME = 'dev'
+           PROJECT_NAME = 'kubesphere-sample-dev'
        }
    
        stages {
            stage ('checkout scm') {
                steps {
-                   git branch: 'master', url: "https://github.com/kubesphere/devops-java-sample.git"
+                   // Please avoid commit your test changes to this repository
+                   git branch: 'master', url: "https://github.com/kubesphere/devops-maven-sample.git"
                }
            }
    
            stage ('unit test') {
                steps {
                    container ('maven') {
-                       sh 'mvn clean -o -gs `pwd`/configuration/settings.xml test'
+                       sh 'mvn clean test'
                    }
                }
            }
@@ -121,7 +121,7 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
            stage ('build & push') {
                steps {
                    container ('maven') {
-                       sh 'mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package'
+                       sh 'mvn -o -Dmaven.test.skip=true clean package'
                        sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
                        withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'
@@ -133,7 +133,13 @@ In this example, all workloads are deployed in `kubesphere-sample-dev`. You must
    
            stage('deploy to dev') {
              steps {
-               kubernetesDeploy(configs: 'deploy/dev-ol/**', enableConfigSubstitution: true, kubeconfigId: "$KUBECONFIG_CREDENTIAL_ID")
+                withCredentials([
+                    kubeconfigFile(
+                    credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                    variable: 'KUBECONFIG')
+                    ]) {
+                    sh 'envsubst < devops-go-sample/deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
+                }
              }
            }
        }

--- a/content/en/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
+++ b/content/en/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
@@ -144,9 +144,8 @@ You must create the projects as shown in the table below in advance. Make sure y
        stage('unit test') {
          steps {
            container('maven') {
-             sh 'mvn clean -o -gs `pwd`/configuration/settings.xml test'
+             sh 'mvn clean test'
            }
-   
          }
        }
        stage('sonarqube analysis') {
@@ -154,7 +153,7 @@ You must create the projects as shown in the table below in advance. Make sure y
            container('maven') {
              withCredentials([string(credentialsId: "$SONAR_CREDENTIAL_ID", variable: 'SONAR_TOKEN')]) {
                withSonarQubeEnv('sonar') {
-                 sh "mvn sonar:sonar -o -gs `pwd`/configuration/settings.xml -Dsonar.login=$SONAR_TOKEN"
+                 sh "mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN"
                }
    
              }
@@ -165,7 +164,7 @@ You must create the projects as shown in the table below in advance. Make sure y
        stage('build & push') {
          steps {
            container('maven') {
-             sh 'mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package'
+             sh 'mvn -Dmaven.test.skip=true clean package'
              sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
              withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'

--- a/content/en/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
+++ b/content/en/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
@@ -129,7 +129,7 @@ You must create the projects as shown in the table below in advance. Make sure y
    
            REGISTRY = 'docker.io'
            DOCKERHUB_NAMESPACE = 'your Docker Hub account ID'
-           APP_NAME = 'devops-java-sample'
+           APP_NAME = 'devops-maven-sample'
            SONAR_CREDENTIAL_ID = 'sonar-token'
            TAG_NAME = "SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
        }
@@ -137,7 +137,7 @@ You must create the projects as shown in the table below in advance. Make sure y
        stage('checkout') {
          steps {
            container('maven') {
-             git branch: 'master', url: 'https://github.com/kubesphere/devops-java-sample.git'
+             git branch: 'master', url: 'https://github.com/kubesphere/devops-maven-sample.git'
            }
          }
        }

--- a/content/en/docs/devops-user-guide/examples/go-project-pipeline.md
+++ b/content/en/docs/devops-user-guide/examples/go-project-pipeline.md
@@ -54,8 +54,8 @@ With the above credentials ready, you can create a pipeline using an example Jen
 
 2. Copy and paste all the content below to the displayed dialog box as an example Jenkinsfile for your pipeline. You must replace the value of `DOCKERHUB_USERNAME`, `DOCKERHUB_CREDENTIAL`, `KUBECONFIG_CREDENTIAL_ID`, and `PROJECT_NAME` with yours. When you finish, click **OK**.
 
-   ```groovy
-   pipeline {
+  ```groovy
+  pipeline {
      agent {
        label 'go'
      }
@@ -95,15 +95,13 @@ With the above credentials ready, you can create a pipeline using an example Jen
        }
        stage ('deploy app') {
          steps {
-           container('go') {
-              withCredentials([
-                kubeconfigFile(
-                  credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
-                  variable: 'KUBECONFIG')
-                ]) {
-                sh 'envsubst < devops-go-sample/manifest/deploy.yaml | kubectl apply -f -'
-              }
-           }
+            withCredentials([
+              kubeconfigFile(
+                credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+              ]) {
+              sh 'envsubst < devops-go-sample/manifest/deploy.yaml | kubectl apply -f -'
+            }
          }
       }
     }

--- a/content/en/docs/devops-user-guide/examples/go-project-pipeline.md
+++ b/content/en/docs/devops-user-guide/examples/go-project-pipeline.md
@@ -67,7 +67,7 @@ With the above credentials ready, you can create a pipeline using an example Jen
        DOCKERHUB_USERNAME = 'Docker Hub Username'
        // Docker image name
        APP_NAME = 'devops-go-sample'
-       // ‘dockerhubid’ is the credentials ID you created in KubeSphere with Docker Hub Access Token
+       // 'dockerhubid' is the credentials ID you created in KubeSphere with Docker Hub Access Token
        DOCKERHUB_CREDENTIAL = credentials('dockerhubid')
        // the kubeconfig credentials ID you created in KubeSphere
        KUBECONFIG_CREDENTIAL_ID = 'go'

--- a/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -73,7 +73,7 @@ With the above credentials ready, you can use the user `project-regular` to crea
        // Docker Hub username
        DOCKERHUB_USERNAME = 'Your Docker Hub username'
        APP_NAME = 'devops-go-sample'
-       // ‘dockerhub-go’ is the Docker Hub credentials ID you created on the KubeSphere console
+       // ‘dockerhub’ is the Docker Hub credentials ID you created on the KubeSphere console
        DOCKERHUB_CREDENTIAL = credentials('dockerhub')
        // the kubeconfig credentials ID you created on the KubeSphere console
        KUBECONFIG_CREDENTIAL_ID = 'kubeconfig'

--- a/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -106,17 +106,13 @@ With the above credentials ready, you can use the user `project-regular` to crea
        
        stage('deploy app to multi cluster') {
          steps {
-           container('go') {
-             script {
-               withCredentials([
-                 kubeconfigFile(
-                   credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
-                   variable: 'KUBECONFIG')
-                 ]) {
-                 sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
-                 }
-               }
-             }
+            withCredentials([
+              kubeconfigFile(
+                credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+              ]) {
+              sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
+              }
            }
          }
        }

--- a/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/en/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -65,10 +65,7 @@ With the above credentials ready, you can use the user `project-regular` to crea
    ```groovy
    pipeline {
      agent {
-       node {
-         label 'maven'
-       }
-   
+       label 'go'
      }
      
      environment {
@@ -77,9 +74,9 @@ With the above credentials ready, you can use the user `project-regular` to crea
        DOCKERHUB_USERNAME = 'Your Docker Hub username'
        APP_NAME = 'devops-go-sample'
        // ‘dockerhub-go’ is the Docker Hub credentials ID you created on the KubeSphere console
-       DOCKERHUB_CREDENTIAL = credentials('dockerhub-go')
+       DOCKERHUB_CREDENTIAL = credentials('dockerhub')
        // the kubeconfig credentials ID you created on the KubeSphere console
-       KUBECONFIG_CREDENTIAL_ID = 'dockerhub-go-kubeconfig'
+       KUBECONFIG_CREDENTIAL_ID = 'kubeconfig'
        // mutli-cluster project name under your own workspace
        MULTI_CLUSTER_PROJECT_NAME = 'demo-multi-cluster'
        // the name of the member cluster where you want to deploy your app
@@ -91,16 +88,15 @@ With the above credentials ready, you can use the user `project-regular` to crea
      stages {
        stage('docker login') {
          steps {
-           container('maven') {
+           container('go') {
              sh 'echo $DOCKERHUB_CREDENTIAL_PSW  | docker login -u $DOCKERHUB_CREDENTIAL_USR --password-stdin'
            }
-   
          }
        }
        
        stage('build & push') {
          steps {
-           container('maven') {
+           container('go') {
              sh 'git clone https://github.com/yuswift/devops-go-sample.git'
              sh 'cd devops-go-sample && docker build -t $REGISTRY/$DOCKERHUB_USERNAME/$APP_NAME .'
              sh 'docker push $REGISTRY/$DOCKERHUB_USERNAME/$APP_NAME'
@@ -110,11 +106,11 @@ With the above credentials ready, you can use the user `project-regular` to crea
        
        stage('deploy app to multi cluster') {
          steps {
-           container('maven') {
+           container('go') {
              script {
                withCredentials([
                  kubeconfigFile(
-                   credentialsId: 'dockerhub-go-kubeconfig',
+                   credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
                    variable: 'KUBECONFIG')
                  ]) {
                  sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'

--- a/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
+++ b/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
@@ -59,7 +59,7 @@ This example pipeline includes the following six stages.
 
 ### Step 2: Create a project
 
-In this tutorial, the example pipeline will deploy the [sample](https://github.com/kubesphere/devops-java-sample/tree/sonarqube) app to a project. Hence, you must create the project (for example, `kubesphere-sample-dev`) in advance. The Deployment and Service of the app will be created automatically in the project once the pipeline runs successfully.
+In this tutorial, the example pipeline will deploy the [sample](https://github.com/kubesphere/devops-maven-sample/tree/sonarqube) app to a project. Hence, you must create the project (for example, `kubesphere-sample-dev`) in advance. The Deployment and Service of the app will be created automatically in the project once the pipeline runs successfully.
 
 You can use the user `project-admin` to create the project. Besides, this user is also the reviewer of the CI/CD pipeline. Make sure the account `project-regular` is invited to the project with the role of `operator`. For more information, see [Create Workspaces, Projects, Users and Roles](../../../quick-start/create-workspace-and-project/).
 
@@ -123,7 +123,7 @@ Pipelines include [declarative pipelines](https://www.jenkins.io/doc/book/pipeli
 
 3. Click **Add Step**. Select **git** from the list as the example code is pulled from GitHub. In the displayed dialog box, fill in the required field. Click **OK** to finish.
 
-   - **URL**. Enter the GitHub repository address `https://github.com/kubesphere/devops-java-sample.git`. Note that this is an example and you need to use your own repository address.
+   - **URL**. Enter the GitHub repository address `https://github.com/kubesphere/devops-maven-sample.git`. Note that this is an example and you need to use your own repository address.
    - **Name**. You do not need to enter the Credential ID for this tutorial. 
    - **Branch**. It defaults to the master branch if you leave it blank. Enter `sonarqube` or leave it blank if you do not need the code analysis stage.
 
@@ -225,7 +225,7 @@ This stage uses SonarQube to test your code. You can skip this stage if you do n
 
    ![nested-step-maven](/images/docs/devops-user-guide/using-devops/create-a-pipeline-using-graphical-editing-panels/nested-step-maven.png)
 
-4. Click **Add Nesting Steps** again and select **shell**. Enter the following command in the command line to build a Docker image based on the [Dockerfile](https://github.com/kubesphere/devops-java-sample/blob/sonarqube/Dockerfile-online). Click **OK** to confirm.
+4. Click **Add Nesting Steps** again and select **shell**. Enter the following command in the command line to build a Docker image based on the [Dockerfile](https://github.com/kubesphere/devops-maven-sample/blob/sonarqube/Dockerfile-online). Click **OK** to confirm.
 
    {{< notice note >}}
 
@@ -298,7 +298,7 @@ This stage uses SonarQube to test your code. You can skip this stage if you do n
 3. Click **Add Step** under the **Deploy to Dev** stage again. Select **kubernetesDeploy** from the list and fill in the following fields in the displayed dialog box. Click **OK** to save it.
 
    - **Kubeconfig**: Select the Kubeconfig you created, such as `demo-kubeconfig`.
-   - **Configuration File Path**: Enter `deploy/no-branch-dev/**`, which is the relative path of the Kubernetes resource [YAML](https://github.com/kubesphere/devops-java-sample/tree/sonarqube/deploy/no-branch-dev) file in the code repository.
+   - **Configuration File Path**: Enter `deploy/no-branch-dev/**`, which is the relative path of the Kubernetes resource [YAML](https://github.com/kubesphere/devops-maven-sample/tree/sonarqube/deploy/no-branch-dev) file in the code repository.
 
    ![kubernetesDeploy](/images/docs/devops-user-guide/using-devops/create-a-pipeline-using-graphical-editing-panels/kubernetesDeploy.png)
 

--- a/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
+++ b/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
@@ -146,7 +146,7 @@ Pipelines include [declarative pipelines](https://www.jenkins.io/doc/book/pipeli
 3. Click **Add Nesting Steps** to add a nested step under the `maven` container. Select **shell** from the list and enter the following command in the command line. Click **OK** to save it.
 
    ```shell
-   mvn clean -o -gs `pwd`/configuration/settings.xml test
+   mvn clean test
    ```
 
    {{< notice note >}}
@@ -190,7 +190,7 @@ This stage uses SonarQube to test your code. You can skip this stage if you do n
 7. Click **shell** and enter the following command in the command line for the sonarqube branch and authentication. Click **OK** to finish.
 
    ```shell
-   mvn sonar:sonar -o -gs `pwd`/configuration/settings.xml -Dsonar.login=$SONAR_TOKEN
+   mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN
    ```
 
    ![sonarqube-shell-new](/images/docs/devops-user-guide/using-devops/create-a-pipeline-using-graphical-editing-panels/sonarqube-shell-new.png)
@@ -220,7 +220,7 @@ This stage uses SonarQube to test your code. You can skip this stage if you do n
 3. Click **Add Nesting Steps** under the `maven` container to add a nested step. Select **shell** from the list, and enter the following command in the displayed dialog box. Click **OK** to finish.
 
    ```shell
-   mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package
+   mvn -Dmaven.test.skip=true clean package
    ```
 
    ![nested-step-maven](/images/docs/devops-user-guide/using-devops/create-a-pipeline-using-graphical-editing-panels/nested-step-maven.png)

--- a/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-jenkinsfile.md
+++ b/content/en/docs/devops-user-guide/how-to-use/create-a-pipeline-using-jenkinsfile.md
@@ -77,9 +77,9 @@ There are eight stages as shown below in this example pipeline.
 
 ### Step 2: Modify the Jenkinsfile in your GitHub repository
 
-1. Log in to GitHub. Fork [devops-java-sample](https://github.com/kubesphere/devops-java-sample) from the GitHub repository to your own GitHub account.
+1. Log in to GitHub. Fork [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) from the GitHub repository to your own GitHub account.
 
-2. In your own GitHub repository of **devops-java-sample**, click the file `Jenkinsfile-online` in the root directory.
+2. In your own GitHub repository of **devops-maven-sample**, click the file `Jenkinsfile-online` in the root directory.
 
 3. Click the edit icon on the right to edit environment variables.
 
@@ -93,7 +93,7 @@ There are eight stages as shown below in this example pipeline.
    | REGISTRY | docker.io | It defaults to `docker.io`, serving as the address of pushing images. |
    | DOCKERHUB\_NAMESPACE | your-dockerhub-account | Replace it with your Docker Hub's account name. It can be the Organization name under the account. |
    | GITHUB\_ACCOUNT | your-github-account | Replace it with your GitHub account name. For example, your GitHub account name is `kubesphere` if your GitHub address is  `https://github.com/kubesphere/`. It can also be the account's Organization name. |
-   | APP\_NAME | devops-java-sample | The application name. |
+   | APP\_NAME | devops-maven-sample | The application name. |
    | SONAR\_CREDENTIAL\_ID | sonar-token | The **Name** you set in KubeSphere for the SonarQube token. It is used for code quality test. |
 
    {{< notice note >}}
@@ -131,7 +131,7 @@ The account `project-admin` needs to be created in advance since it is the revie
 
 3. In the **GitHub** tab, select **github-token** from the drop-down list under **Credential**, and then click **OK** to select your repository.
 
-4. Choose your GitHub account. All the repositories related to this token will be listed on the right. Select **devops-java-sample** and click **Select**. Click **Next** to continue.
+4. Choose your GitHub account. All the repositories related to this token will be listed on the right. Select **devops-maven-sample** and click **Select**. Click **Next** to continue.
 
 5. In **Advanced Settings**, select the checkbox next to **Delete outdated branches**. In this tutorial, you can use the default value of **Branch Retention Period (days)** and **Maximum Branches**.
 
@@ -225,7 +225,7 @@ The account `project-admin` needs to be created in advance since it is the revie
 
 ### Step 6: Check pipeline status
 
-1. In **Task Status**, you can see how a pipeline is running. Please note that the pipeline will keep initializing for several minutes after it is just created. There are eight stages in the sample pipeline and they have been defined separately in [Jenkinsfile-online](https://github.com/kubesphere/devops-java-sample/blob/sonarqube/Jenkinsfile-online).
+1. In **Task Status**, you can see how a pipeline is running. Please note that the pipeline will keep initializing for several minutes after it is just created. There are eight stages in the sample pipeline and they have been defined separately in [Jenkinsfile-online](https://github.com/kubesphere/devops-maven-sample/blob/sonarqube/Jenkinsfile-online).
 
 2. Check the pipeline running logs by clicking **View Logs** in the upper-right corner. You can see the dynamic log output of the pipeline, including any errors that may stop the pipeline from running. For each stage, you click it to inspect logs, which can be downloaded to your local machine for further analysis.
 

--- a/content/en/docs/devops-user-guide/how-to-use/gitlab-multibranch-pipeline.md
+++ b/content/en/docs/devops-user-guide/how-to-use/gitlab-multibranch-pipeline.md
@@ -38,7 +38,7 @@ In KubeSphere 3.1.x and later, you can create a multi-branch pipeline with GitLa
 
 ### Step 2: Modify the Jenkinsfile in your GitLab repository
 
-1. Log in to GitLab and create a public project. Click **Import project/repository**, select **Repo by URL** to enter the URL of [devops-java-sample](https://github.com/kubesphere/devops-java-sample), select **Public** for **Visibility Level**, and then click **Create project**.
+1. Log in to GitLab and create a public project. Click **Import project/repository**, select **Repo by URL** to enter the URL of [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample), select **Public** for **Visibility Level**, and then click **Create project**.
 
 2. In the project just created, create a new branch from the master branch and name it `gitlab-demo`.
 
@@ -70,7 +70,7 @@ You need to create two projects, such as `kubesphere-sample-dev` and `kubesphere
 
 2. Provide the basic information in the displayed dialog box. Name it `gitlab-multi-branch` and select a code repository.
 
-3. On the **GitLab** tab, select the default option `https://gitlab.com` for **GitLab Server Address**, enter the username of the GitLab project owner for **Project Group/Owner**, and then select the `devops-java-sample` repository from the drop-down list for **Code Repository**. Click **√** in the lower-right corner and then click **Next**.
+3. On the **GitLab** tab, select the default option `https://gitlab.com` for **GitLab Server Address**, enter the username of the GitLab project owner for **Project Group/Owner**, and then select the `devops-maven-sample` repository from the drop-down list for **Code Repository**. Click **√** in the lower-right corner and then click **Next**.
 
    {{< notice note >}}
 

--- a/content/en/docs/devops-user-guide/how-to-use/pipeline-webhook.md
+++ b/content/en/docs/devops-user-guide/how-to-use/pipeline-webhook.md
@@ -29,7 +29,7 @@ This tutorial demonstrates how to trigger a pipeline by using a webhook.
 
 ### Set a webhook in the GitHub repository
 
-1. Log in to GitHub and go to your own repository `devops-java-sample`.
+1. Log in to GitHub and go to your own repository `devops-maven-sample`.
 
 2. Click **Settings**, click **Webhooks**, and click **Add webhook**.
 

--- a/content/en/docs/project-user-guide/image-builder/binary-to-image.md
+++ b/content/en/docs/project-user-guide/image-builder/binary-to-image.md
@@ -20,7 +20,7 @@ For demonstration and testing purposes, here are some example artifacts you can 
 | [b2i-war-java11.war](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-war-java11.war) | [springmvc5](https://github.com/kubesphere/s2i-java-container/tree/master/tomcat/examples/springmvc5) |
 | [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-binary) | [devops-go-sample](https://github.com/runzexia/devops-go-sample) |
 | [b2i-jar-java11.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java11.jar) | [ java-maven-example](https://github.com/kubesphere/s2i-java-container/tree/master/java/examples/maven) |
-| [b2i-jar-java8.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java8.jar) | [devops-java-sample](https://github.com/kubesphere/devops-java-sample) |
+| [b2i-jar-java8.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java8.jar) | [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) |
 
 ## Prerequisites
 

--- a/content/en/docs/project-user-guide/image-builder/source-to-image.md
+++ b/content/en/docs/project-user-guide/image-builder/source-to-image.md
@@ -23,7 +23,7 @@ This tutorial demonstrates how to use S2I to import source code of a Java sample
 
 ### Step 1: Fork the example repository
 
-Log in to GitHub and fork the GitHub repository [devops-java-sample](https://github.com/kubesphere/devops-java-sample) to your personal GitHub account.
+Log in to GitHub and fork the GitHub repository [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) to your personal GitHub account.
 
 ### Step 2: Create Secrets
 

--- a/content/zh/blogs/DevOps-pipeline-remove-Docker-dependencies.md
+++ b/content/zh/blogs/DevOps-pipeline-remove-Docker-dependencies.md
@@ -61,7 +61,7 @@ containerd github.com/containerd/containerd v1.4.3 269548fa27e0089a8b8278fc4
 
 这里主要用于测试，因此没有将 Podman 安装到基础镜像中，而是在流水线中实时安装。生产环境，应该提前安装，以加快执行速度。
 
-以 [devops-java-sample](https://github.com/kubesphere/devops-java-sample) 为例，流水线中主要需要增加如下部分：
+以 [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) 为例，流水线中主要需要增加如下部分：
 
 ```groovy
         stage ('install podman') {
@@ -78,11 +78,11 @@ containerd github.com/containerd/containerd v1.4.3 269548fa27e0089a8b8278fc4
         }
 ```
 
-相关脚本，已经更新到 [Podman](https://github.com/kubesphere/devops-java-sample/tree/podman) 分支中。
+相关脚本，已经更新到 [Podman](https://github.com/kubesphere/devops-maven-sample/tree/podman) 分支中。
 
-## 测试 devops-java-sample 项目
+## 测试 devops-maven-sample 项目
 
-使用 devops-java-sample 创建 SCM 流水线，Jenkinsfile 路径设置为 Jenkinsfile-online，并配置好相关的秘钥值。
+使用 devops-maven-sample 创建 SCM 流水线，Jenkinsfile 路径设置为 Jenkinsfile-online，并配置好相关的秘钥值。
 
 最后执行时，在 Podman 分支上可以看到如下日志：
 

--- a/content/zh/blogs/create-pipeline-across-multi-clusters.md
+++ b/content/zh/blogs/create-pipeline-across-multi-clusters.md
@@ -121,7 +121,7 @@ pipeline {
 
         REGISTRY = 'docker.io'
         DOCKERHUB_NAMESPACE = 'shaowenchen'
-        APP_NAME = 'devops-java-sample'
+        APP_NAME = 'devops-maven-sample'
         SONAR_CREDENTIAL_ID = 'sonar-token'
         TAG_NAME = "SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
     }
@@ -129,7 +129,7 @@ pipeline {
     stage('checkout') {
       steps {
         container('maven') {
-          git branch: 'master', url: 'https://github.com/kubesphere/devops-java-sample.git'
+          git branch: 'master', url: 'https://github.com/kubesphere/devops-maven-sample.git'
         }
       }
     }

--- a/content/zh/blogs/create-pipeline-across-multi-clusters.md
+++ b/content/zh/blogs/create-pipeline-across-multi-clusters.md
@@ -178,19 +178,37 @@ pipeline {
     }
     stage('deploy to dev') {
       steps {
-        kubernetesDeploy(configs: 'deploy/dev-ol/**', enableConfigSubstitution: true, kubeconfigId: "$DEV_KUBECONFIG_CREDENTIAL_ID")
+        withCredentials([
+            kubeconfigFile(
+            credentialsId: env.DEV_KUBECONFIG_CREDENTIAL_ID,
+            variable: 'KUBECONFIG')
+            ]) {
+            sh 'envsubst < deploy/dev-all-in-one/devops-sample.yaml | kubectl apply -f -'
+        }
       }
     }
     stage('deploy to staging') {
       steps {
         input(id: 'deploy-to-staging', message: 'deploy to staging?')
-        kubernetesDeploy(configs: 'deploy/prod-ol/**', enableConfigSubstitution: true, kubeconfigId: "$TEST_KUBECONFIG_CREDENTIAL_ID")
+        withCredentials([
+            kubeconfigFile(
+            credentialsId: env.TEST_KUBECONFIG_CREDENTIAL_ID,
+            variable: 'KUBECONFIG')
+            ]) {
+            sh 'envsubst < deploy/prod-all-in-one/devops-sample.yaml | kubectl apply -f -'
+        }
       }
     }
     stage('deploy to production') {
       steps {
         input(id: 'deploy-to-production', message: 'deploy to production?')
-        kubernetesDeploy(configs: 'deploy/prod-ol/**', enableConfigSubstitution: true, kubeconfigId: "$PROD_KUBECONFIG_CREDENTIAL_ID")
+        withCredentials([
+            kubeconfigFile(
+            credentialsId: env.PROD_KUBECONFIG_CREDENTIAL_ID,
+            variable: 'KUBECONFIG')
+            ]) {
+            sh 'envsubst < deploy/prod-all-in-one/devops-sample.yaml | kubectl apply -f -'
+        }
       }
     }
   }

--- a/content/zh/blogs/create-pipeline-across-multi-clusters.md
+++ b/content/zh/blogs/create-pipeline-across-multi-clusters.md
@@ -136,9 +136,8 @@ pipeline {
     stage('unit test') {
       steps {
         container('maven') {
-          sh 'mvn clean -o -gs `pwd`/configuration/settings.xml test'
+          sh 'mvn clean test'
         }
-
       }
     }
     stage('sonarqube analysis') {
@@ -146,7 +145,7 @@ pipeline {
         container('maven') {
           withCredentials([string(credentialsId: "$SONAR_CREDENTIAL_ID", variable: 'SONAR_TOKEN')]) {
             withSonarQubeEnv('sonar') {
-              sh "mvn sonar:sonar -o -gs `pwd`/configuration/settings.xml -Dsonar.login=$SONAR_TOKEN"
+              sh "mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN"
             }
 
           }
@@ -157,7 +156,7 @@ pipeline {
     stage('build & push') {
       steps {
         container('maven') {
-          sh 'mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package'
+          sh 'mvn -Dmaven.test.skip=true clean package'
           sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
           withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
             sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'

--- a/content/zh/blogs/kubesphere-argocd.md
+++ b/content/zh/blogs/kubesphere-argocd.md
@@ -49,7 +49,7 @@ Argo CD 支持的 Kubernetes 配置清单包括 helm charts、kustomize 或纯 Y
 
 源码仓库可参考以下链接，离线环境原因，这里选择第二个示例 spring-demo：
 
-+ [https://github.com/KubeSphere/DevOps-java-sample](https://github.com/KubeSphere/DevOps-java-sample)
++ [https://github.com/KubeSphere/devops-maven-sample](https://github.com/KubeSphere/devops-maven-sample)
 + [https://github.com/willzhang/spring-demo](https://github.com/willzhang/spring-demo)
 
 yaml 文件仓库可参考以下链接，这里命名为 argocd-gitops：

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -83,11 +83,9 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
 
    ```groovy
    pipeline {
-     agent {
-       node {
-         label 'maven'
+       agent {
+           label 'maven'
        }
-     }
    
        parameters {
            string(name:'TAG_NAME',defaultValue: '',description:'')
@@ -101,19 +99,21 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
            DOCKERHUB_NAMESPACE = 'Docker Hub Namespace'
            APP_NAME = 'devops-java-sample'
            BRANCH_NAME = 'dev'
+           PROJECT_NAME = 'kubesphere-sample-dev'
        }
    
        stages {
            stage ('checkout scm') {
                steps {
-                   git branch: 'master', url: "https://github.com/kubesphere/devops-java-sample.git"
+                   // 下面的项目是为了大家方便体验功能的示例项目，请大家避免把自己的测试性的修改提交 PR 到该仓库
+                   git branch: 'master', url: "https://github.com/kubesphere/devops-maven-sample.git"
                }
            }
    
            stage ('unit test') {
                steps {
                    container ('maven') {
-                       sh 'mvn clean -o -gs `pwd`/configuration/settings.xml test'
+                       sh 'mvn clean test'
                    }
                }
            }
@@ -121,7 +121,7 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
            stage ('build & push') {
                steps {
                    container ('maven') {
-                       sh 'mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package'
+                       sh 'mvn -o -Dmaven.test.skip=true clean package'
                        sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
                        withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'
@@ -133,7 +133,13 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
    
            stage('deploy to dev') {
              steps {
-               kubernetesDeploy(configs: 'deploy/dev-ol/**', enableConfigSubstitution: true, kubeconfigId: "$KUBECONFIG_CREDENTIAL_ID")
+                withCredentials([
+                    kubeconfigFile(
+                    credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                    variable: 'KUBECONFIG')
+                    ]) {
+                    sh 'envsubst < devops-go-sample/deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
+                }
              }
            }
        }

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -121,7 +121,7 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
            stage ('build & push') {
                steps {
                    container ('maven') {
-                       sh 'mvn -o -Dmaven.test.skip=true clean package'
+                       sh 'mvn -Dmaven.test.skip=true clean package'
                        sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
                        withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -105,7 +105,7 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
        stages {
            stage ('checkout scm') {
                steps {
-                   // 下面的项目是为了大家方便体验功能的示例项目，请大家避免把自己的测试性的修改提交 PR 到该仓库
+                   // 下方所用的 GitHub 仓库仅用作体验功能的示例，请避免向该仓库提交包含测试性改动的 PR
                    git branch: 'master', url: "https://github.com/kubesphere/devops-maven-sample.git"
                }
            }

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -57,8 +57,8 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
 ### Maven 工程准备工作
 
 - 确保您在开发设备上成功构建 Maven 工程。
-- 添加 Dockerfile 至工程仓库以构建镜像。有关更多信息，请参考 <https://github.com/kubesphere/devops-java-sample/blob/master/Dockerfile-online>。
-- 添加 YAML 文件至工程仓库以部署工作负载。有关更多信息，请参考 <https://github.com/kubesphere/devops-java-sample/tree/master/deploy/dev-ol>。如果有多个不同环境，您需要准备多个部署文件。
+- 添加 Dockerfile 至工程仓库以构建镜像。有关更多信息，请参考 <https://github.com/kubesphere/devops-maven-sample/blob/master/Dockerfile-online>。
+- 添加 YAML 文件至工程仓库以部署工作负载。有关更多信息，请参考 <https://github.com/kubesphere/devops-maven-sample/tree/master/deploy/dev-ol>。如果有多个不同环境，您需要准备多个部署文件。
 
 ### 创建凭证
 
@@ -97,7 +97,7 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
            REGISTRY = 'docker.io'
            // 需要更改为您自己的 Docker Hub Namespace
            DOCKERHUB_NAMESPACE = 'Docker Hub Namespace'
-           APP_NAME = 'devops-java-sample'
+           APP_NAME = 'devops-maven-sample'
            BRANCH_NAME = 'dev'
            PROJECT_NAME = 'kubesphere-sample-dev'
        }

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -138,7 +138,7 @@ kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
                     credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
                     variable: 'KUBECONFIG')
                     ]) {
-                    sh 'envsubst < devops-go-sample/deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
+                    sh 'envsubst < deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
                 }
              }
            }

--- a/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
+++ b/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
@@ -144,9 +144,8 @@ weight: 11440
        stage('unit test') {
          steps {
            container('maven') {
-             sh 'mvn clean -o -gs `pwd`/configuration/settings.xml test'
+             sh 'mvn clean test'
            }
-   
          }
        }
        stage('sonarqube analysis') {
@@ -154,18 +153,16 @@ weight: 11440
            container('maven') {
              withCredentials([string(credentialsId: "$SONAR_CREDENTIAL_ID", variable: 'SONAR_TOKEN')]) {
                withSonarQubeEnv('sonar') {
-                 sh "mvn sonar:sonar -o -gs `pwd`/configuration/settings.xml -Dsonar.login=$SONAR_TOKEN"
+                 sh "mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN"
                }
-   
              }
            }
-   
          }
        }
        stage('build & push') {
          steps {
            container('maven') {
-             sh 'mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package'
+             sh 'mvn -Dmaven.test.skip=true clean package'
              sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
              withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
                sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'

--- a/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
+++ b/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
@@ -168,9 +168,7 @@ weight: 11440
                sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'
                sh 'docker push  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER'
              }
-   
            }
-   
          }
        }
        stage('push latest') {
@@ -179,29 +177,45 @@ weight: 11440
              sh 'docker tag  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:latest '
              sh 'docker push  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:latest '
            }
-   
          }
        }
        stage('deploy to dev') {
          steps {
-           kubernetesDeploy(configs: 'deploy/dev-ol/**', enableConfigSubstitution: true, kubeconfigId: "$DEV_KUBECONFIG_CREDENTIAL_ID")
+            withCredentials([
+                kubeconfigFile(
+                credentialsId: env.DEV_KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+                ]) {
+                sh 'envsubst < deploy/dev-all-in-one/devops-sample.yaml | kubectl apply -f -'
+            }
          }
        }
        stage('deploy to staging') {
          steps {
-           input(id: 'deploy-to-staging', message: 'deploy to staging?')
-           kubernetesDeploy(configs: 'deploy/prod-ol/**', enableConfigSubstitution: true, kubeconfigId: "$TEST_KUBECONFIG_CREDENTIAL_ID")
+            input(id: 'deploy-to-staging', message: 'deploy to staging?')
+            withCredentials([
+                kubeconfigFile(
+                credentialsId: env.TEST_KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+                ]) {
+                sh 'envsubst < deploy/prod-all-in-one/devops-sample.yaml | kubectl apply -f -'
+            }
          }
        }
        stage('deploy to production') {
          steps {
-           input(id: 'deploy-to-production', message: 'deploy to production?')
-           kubernetesDeploy(configs: 'deploy/prod-ol/**', enableConfigSubstitution: true, kubeconfigId: "$PROD_KUBECONFIG_CREDENTIAL_ID")
+            input(id: 'deploy-to-production', message: 'deploy to production?')
+            withCredentials([
+                kubeconfigFile(
+                credentialsId: env.PROD_KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+                ]) {
+                sh 'envsubst < deploy/prod-all-in-one/devops-sample.yaml | kubectl apply -f -'
+            }
          }
        }
      }
    }
-   
    ```
 
    {{< notice note >}}

--- a/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
+++ b/content/zh/docs/devops-user-guide/examples/create-multi-cluster-pipeline.md
@@ -129,7 +129,7 @@ weight: 11440
    
            REGISTRY = 'docker.io'
            DOCKERHUB_NAMESPACE = 'your Docker Hub account ID'
-           APP_NAME = 'devops-java-sample'
+           APP_NAME = 'devops-maven-sample'
            SONAR_CREDENTIAL_ID = 'sonar-token'
            TAG_NAME = "SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
        }
@@ -137,7 +137,7 @@ weight: 11440
        stage('checkout') {
          steps {
            container('maven') {
-             git branch: 'master', url: 'https://github.com/kubesphere/devops-java-sample.git'
+             git branch: 'master', url: 'https://github.com/kubesphere/devops-maven-sample.git'
            }
          }
        }

--- a/content/zh/docs/devops-user-guide/examples/go-project-pipeline.md
+++ b/content/zh/docs/devops-user-guide/examples/go-project-pipeline.md
@@ -96,14 +96,13 @@ weight: 11410
 
        stage ('deploy app') {
          steps {
-           container('go') {
-              withCredentials([
-                kubeconfigFile(
-                  credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
-                  variable: 'KUBECONFIG')
-                ]) {
-                sh 'envsubst < devops-go-sample/manifest/deploy.yaml | kubectl apply -f -'
-           }
+            withCredentials([
+              kubeconfigFile(
+                credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+              ]) {
+              sh 'envsubst < devops-go-sample/manifest/deploy.yaml | kubectl apply -f -'
+            }
          }
        }
      }

--- a/content/zh/docs/devops-user-guide/examples/go-project-pipeline.md
+++ b/content/zh/docs/devops-user-guide/examples/go-project-pipeline.md
@@ -67,7 +67,7 @@ weight: 11410
        DOCKERHUB_USERNAME = 'Docker Hub Username'
        // Docker 镜像名称
        APP_NAME = 'devops-go-sample'
-       // ‘dockerhubid’ 是您在 KubeSphere 用 Docker Hub 访问令牌创建的凭证 ID
+       // 'dockerhubid' 是您在 KubeSphere 用 Docker Hub 访问令牌创建的凭证 ID
        DOCKERHUB_CREDENTIAL = credentials('dockerhubid')
        // 您在 KubeSphere 创建的 kubeconfig 凭证 ID
        KUBECONFIG_CREDENTIAL_ID = 'go'

--- a/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -106,17 +106,13 @@ weight: 11420
        
        stage('deploy app to multi cluster') {
          steps {
-           container('go') {
-             script {
-               withCredentials([
-                 kubeconfigFile(
-                   credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
-                   variable: 'KUBECONFIG')
-                 ]) {
-                    sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
-                 }
-               }
-             }
+            withCredentials([
+              kubeconfigFile(
+                credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
+                variable: 'KUBECONFIG')
+              ]) {
+                sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
+              }
            }
          }
        }

--- a/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -73,7 +73,7 @@ weight: 11420
        // Docker Hub 用户名
        DOCKERHUB_USERNAME = 'Your Docker Hub username'
        APP_NAME = 'devops-go-sample'
-       // ‘dockerhub-go’ 即您在 KubeSphere 控制台上创建的 Docker Hub 凭证 ID
+       // ‘dockerhub’ 即您在 KubeSphere 控制台上创建的 Docker Hub 凭证 ID
        DOCKERHUB_CREDENTIAL = credentials('dockerhub')
        // 您在 KubeSphere 控制台上创建的 kubeconfig 凭证 ID
        KUBECONFIG_CREDENTIAL_ID = 'kubeconfig'

--- a/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -65,10 +65,7 @@ weight: 11420
    ```groovy
    pipeline {
      agent {
-       node {
-         label 'maven'
-       }
-   
+       label 'go'
      }
      
      environment {
@@ -77,9 +74,9 @@ weight: 11420
        DOCKERHUB_USERNAME = 'Your Docker Hub username'
        APP_NAME = 'devops-go-sample'
        // ‘dockerhub-go’ 即您在 KubeSphere 控制台上创建的 Docker Hub 凭证 ID
-       DOCKERHUB_CREDENTIAL = credentials('dockerhub-go')
+       DOCKERHUB_CREDENTIAL = credentials('dockerhub')
        // 您在 KubeSphere 控制台上创建的 kubeconfig 凭证 ID
-       KUBECONFIG_CREDENTIAL_ID = dockerhub-go-kubeconfig
+       KUBECONFIG_CREDENTIAL_ID = 'kubeconfig'
        // 您企业空间中的多集群项目名称
        MULTI_CLUSTER_PROJECT_NAME = 'demo-multi-cluster'
        // 您用来部署应用的成员集群名称
@@ -91,16 +88,15 @@ weight: 11420
      stages {
        stage('docker login') {
          steps {
-           container('maven') {
+           container('go') {
              sh 'echo $DOCKERHUB_CREDENTIAL_PSW  | docker login -u $DOCKERHUB_CREDENTIAL_USR --password-stdin'
            }
-   
          }
        }
        
        stage('build & push') {
          steps {
-           container('maven') {
+           container('go') {
              sh 'git clone https://github.com/yuswift/devops-go-sample.git'
              sh 'cd devops-go-sample && docker build -t $REGISTRY/$DOCKERHUB_USERNAME/$APP_NAME .'
              sh 'docker push $REGISTRY/$DOCKERHUB_USERNAME/$APP_NAME'
@@ -110,11 +106,11 @@ weight: 11420
        
        stage('deploy app to multi cluster') {
          steps {
-           container('maven') {
+           container('go') {
              script {
                withCredentials([
                  kubeconfigFile(
-                   credentialsId: 'dockerhub-go-kubeconfig',
+                   credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
                    variable: 'KUBECONFIG')
                  ]) {
                  sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'

--- a/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
+++ b/content/zh/docs/devops-user-guide/examples/multi-cluster-project-example.md
@@ -113,7 +113,7 @@ weight: 11420
                    credentialsId: env.KUBECONFIG_CREDENTIAL_ID,
                    variable: 'KUBECONFIG')
                  ]) {
-                 sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
+                    sh 'envsubst < devops-go-sample/manifest/multi-cluster-deploy.yaml | kubectl apply -f -'
                  }
                }
              }

--- a/content/zh/docs/devops-user-guide/examples/use-nexus-in-pipelines.md
+++ b/content/zh/docs/devops-user-guide/examples/use-nexus-in-pipelines.md
@@ -116,9 +116,7 @@ weight: 11450
    ```groovy
    pipeline {
        agent {
-         node {
            label 'maven'
-         }
        }
        stages {
            stage ('clone') {

--- a/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
+++ b/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
@@ -59,7 +59,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 
 ### 步骤 2：创建项目
 
-在本教程中，示例流水线会将 [sample](https://github.com/kubesphere/devops-java-sample/tree/sonarqube) 应用部署至一个项目。因此，您必须先创建一个项目（例如 `kubesphere-sample-dev`）。待流水线成功运行，会在该项目中自动创建该应用的部署和服务。
+在本教程中，示例流水线会将 [sample](https://github.com/kubesphere/devops-maven-sample/tree/sonarqube) 应用部署至一个项目。因此，您必须先创建一个项目（例如 `kubesphere-sample-dev`）。待流水线成功运行，会在该项目中自动创建该应用的部署和服务。
 
 您可以使用 `project-admin` 帐户创建项目。此外，该用户也是 CI/CD 流水线的审核员。请确保将 `project-regular` 帐户邀请至该项目并授予 `operator` 角色。有关更多信息，请参见[创建企业空间、项目、用户和角色](../../../quick-start/create-workspace-and-project/)。
 
@@ -123,7 +123,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 
 3. 点击**添加步骤**。在列表中选择 **git**，以从 GitHub 拉取示例代码。在弹出的对话框中，填写必需的字段。点击**确定**完成操作。
 
-   - **URL**：输入 GitHub 仓库地址 `https://github.com/kubesphere/devops-java-sample.git`。请注意，这里是示例地址，您需要使用您自己的仓库地址。
+   - **URL**：输入 GitHub 仓库地址 `https://github.com/kubesphere/devops-maven-sample.git`。请注意，这里是示例地址，您需要使用您自己的仓库地址。
    - **凭证 ID**：本教程中无需输入凭证 ID。
    - **分支**：如果您将其留空，则默认为 master 分支。请输入 `sonarqube`，或者如果您不需要代码分析阶段，请将其留空。
 
@@ -225,7 +225,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 
    ![maven 嵌套步骤](/images/docs/zh-cn/devops-user-guide/use-devops/create-a-pipeline-using-graphical-editing-panel/nested_step_maven.png)
 
-4. 再次点击**添加嵌套步骤**，选择 **shell**。在命令行中输入以下命令，以根据 [Dockerfile](https://github.com/kubesphere/devops-java-sample/blob/sonarqube/Dockerfile-online) 构建 Docker 镜像。点击**确定**确认操作。
+4. 再次点击**添加嵌套步骤**，选择 **shell**。在命令行中输入以下命令，以根据 [Dockerfile](https://github.com/kubesphere/devops-maven-sample/blob/sonarqube/Dockerfile-online) 构建 Docker 镜像。点击**确定**确认操作。
 
    {{< notice note >}}
 
@@ -298,7 +298,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 3. 再次点击 **Deploy to Dev** 阶段下的**添加步骤**。在列表中选择 **kubernetesDeploy** 并在弹出的对话框中填写以下字段。点击**确定**保存操作。
 
    - **Kubeconfig**：选择您创建的 Kubeconfig，例如 `demo-kubeconfig`。
-   - **配置文件路径**：输入 `deploy/no-branch-dev/**`，即代码仓库中 Kubernetes 资源 [YAML](https://github.com/kubesphere/devops-java-sample/tree/sonarqube/deploy/no-branch-dev) 文件的相对路径。
+   - **配置文件路径**：输入 `deploy/no-branch-dev/**`，即代码仓库中 Kubernetes 资源 [YAML](https://github.com/kubesphere/devops-maven-sample/tree/sonarqube/deploy/no-branch-dev) 文件的相对路径。
 
    ![kubernetesDeploy](/images/docs/zh-cn/devops-user-guide/use-devops/create-a-pipeline-using-graphical-editing-panel/kubernetesDeploy_set.png)
 

--- a/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
+++ b/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-graphical-editing-panel.md
@@ -146,7 +146,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 3. 点击**添加嵌套步骤**，在 `maven` 容器下添加一个嵌套步骤。在列表中选择 **shell** 并在命令行中输入以下命令。点击**确定**保存操作。
 
    ```shell
-   mvn clean -o -gs `pwd`/configuration/settings.xml test
+   mvn clean test
    ```
 
    {{< notice note >}}
@@ -190,7 +190,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 7. 点击 **shell** 并在命令行中输入以下命令，用于 sonarqube 分支和认证，点击**确定**完成操作。
 
    ```shell
-   mvn sonar:sonar -o -gs `pwd`/configuration/settings.xml -Dsonar.login=$SONAR_TOKEN
+   mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN
    ```
 
    ![新的 SonarQube shell](/images/docs/zh-cn/devops-user-guide/use-devops/create-a-pipeline-using-graphical-editing-panel/sonarqube_shell_new.png)
@@ -220,7 +220,7 @@ KubeSphere 中的图形编辑面板包含用于 Jenkins [阶段 (Stage)](https:/
 3. 点击 `maven` 容器下的**添加嵌套步骤**添加一个嵌套步骤。在列表中选择 **shell** 并在弹出窗口中输入以下命令，点击**确定**完成操作。
 
    ```shell
-   mvn -o -Dmaven.test.skip=true -gs `pwd`/configuration/settings.xml clean package
+   mvn -Dmaven.test.skip=true clean package
    ```
 
    ![maven 嵌套步骤](/images/docs/zh-cn/devops-user-guide/use-devops/create-a-pipeline-using-graphical-editing-panel/nested_step_maven.png)

--- a/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-jenkinsfile.md
+++ b/content/zh/docs/devops-user-guide/how-to-use/create-a-pipeline-using-jenkinsfile.md
@@ -77,9 +77,9 @@ KubeSphere 中可以创建两种类型的流水线：一种是本教程中介绍
 
 ### 步骤 2：在 GitHub 仓库中修改 Jenkinsfile
 
-1. 登录 GitHub 并 Fork GitHub 仓库 [devops-java-sample](https://github.com/kubesphere/devops-java-sample) 至您的 GitHub 个人帐户。
+1. 登录 GitHub 并 Fork GitHub 仓库 [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) 至您的 GitHub 个人帐户。
 
-2. 在您自己的 GitHub 仓库 **devops-java-sample** 中，点击根目录中的文件 `Jenkinsfile-online`。
+2. 在您自己的 GitHub 仓库 **devops-maven-sample** 中，点击根目录中的文件 `Jenkinsfile-online`。
 
 3. 点击右侧的编辑图标，编辑环境变量。
 
@@ -93,7 +93,7 @@ KubeSphere 中可以创建两种类型的流水线：一种是本教程中介绍
    | REGISTRY | docker.io | 默认为 `docker.io`，用作推送镜像的地址。 |
    | DOCKERHUB\_NAMESPACE | your-dockerhub-account | 请替换为您的 Docker Hub 帐户名，也可以替换为该帐户下的 Organization 名称。 |
    | GITHUB\_ACCOUNT | your-github-account | 请替换为您的 GitHub 帐户名。例如，如果您的 GitHub 地址是 `https://github.com/kubesphere/`，则您的 GitHub 帐户名为 `kubesphere`，也可以替换为该帐户下的 Organization 名称。 |
-   | APP\_NAME | devops-java-sample | 应用名称。 |
+   | APP\_NAME | devops-maven-sample | 应用名称。 |
    | SONAR\_CREDENTIAL\_ID | sonar-token | 您在 KubeSphere 中为 SonarQube 令牌设置的**名称**，用于代码质量检测。 |
 
    {{< notice note >}}
@@ -131,7 +131,7 @@ KubeSphere 中可以创建两种类型的流水线：一种是本教程中介绍
 
 3. 在 **GitHub** 选项卡，从**凭证**的下拉菜单中选择 **github-token**，然后点击**确定**来选择您的仓库。
 
-4. 选择您的 GitHub 帐户，与该令牌相关的所有仓库将在右侧列出。选择 **devops-java-sample** 并点击**选择**，点击**下一步**继续。
+4. 选择您的 GitHub 帐户，与该令牌相关的所有仓库将在右侧列出。选择 **devops-maven-sample** 并点击**选择**，点击**下一步**继续。
 
 5. 在**高级设置**中，选中**删除旧分支**旁边的方框。本教程中，您可以为**分支保留天数（天）**和**分支最大数量**使用默认值。
 
@@ -225,7 +225,7 @@ KubeSphere 中可以创建两种类型的流水线：一种是本教程中介绍
 
 ### 步骤 6：检查流水线状态
 
-1. 在**运行状态**中，您可以查看流水线的运行状态。请注意，流水线在刚创建后将继续初始化几分钟。示例流水线有八个阶段，它们已在 [Jenkinsfile-online](https://github.com/kubesphere/devops-java-sample/blob/sonarqube/Jenkinsfile-online) 中单独定义。
+1. 在**运行状态**中，您可以查看流水线的运行状态。请注意，流水线在刚创建后将继续初始化几分钟。示例流水线有八个阶段，它们已在 [Jenkinsfile-online](https://github.com/kubesphere/devops-maven-sample/blob/sonarqube/Jenkinsfile-online) 中单独定义。
 
 2. 点击右上角的**查看日志**来查看流水线运行日志。您可以看到流水线的动态日志输出，包括可能导致流水线无法运行的错误。对于每个阶段，您都可以点击该阶段来查看其日志，而且可以将日志下载到本地计算机进行进一步分析。
 

--- a/content/zh/docs/devops-user-guide/how-to-use/gitlab-multibranch-pipeline.md
+++ b/content/zh/docs/devops-user-guide/how-to-use/gitlab-multibranch-pipeline.md
@@ -38,7 +38,7 @@ weight: 11291
 
 ### 步骤 2：在 GitLab 仓库中编辑 Jenkinsfile
 
-1. 登录 GitLab 并创建一个公开项目。点击**导入项目**，选择**从 URL 导入仓库**，然后输入 [devops-java-sample](https://github.com/kubesphere/devops-java-sample) 的 URL。可见性级别选择**公开**，然后点击**新建项目**。
+1. 登录 GitLab 并创建一个公开项目。点击**导入项目**，选择**从 URL 导入仓库**，然后输入 [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) 的 URL。可见性级别选择**公开**，然后点击**新建项目**。
 
 2. 在刚刚创建的项目中，从 master 分支中创建一个新分支，命名为 `gitlab-demo`。
 
@@ -70,7 +70,7 @@ weight: 11291
 
 2. 在出现的对话框中填写基本信息。将流水线的名称设置为 `gitlab-multi-branch` 并选择一个代码仓库。
 
-3. 在 **GitLab** 选项卡下的 **GitLab 服务器地址**中选择默认选项 `https://gitlab.com`，在**项目组/所有者**中输入该 GitLab 项目所属组的名称，然后从**代码仓库**的下拉菜单中选择 `devops-java-sample` 仓库。点击右下角的 **√**，然后点击**下一步**。
+3. 在 **GitLab** 选项卡下的 **GitLab 服务器地址**中选择默认选项 `https://gitlab.com`，在**项目组/所有者**中输入该 GitLab 项目所属组的名称，然后从**代码仓库**的下拉菜单中选择 `devops-maven-sample` 仓库。点击右下角的 **√**，然后点击**下一步**。
 
    {{< notice note >}}
 

--- a/content/zh/docs/devops-user-guide/how-to-use/pipeline-webhook.md
+++ b/content/zh/docs/devops-user-guide/how-to-use/pipeline-webhook.md
@@ -28,7 +28,7 @@ weight: 11293
 
 ### 在 GitHub 仓库中设置 webhook
 
-1. 登录您的 GitHub，并转到 `devops-java-sample` 仓库。
+1. 登录您的 GitHub，并转到 `devops-maven-sample` 仓库。
 
 2. 点击 **Settings**，然后点击 **Webhooks**，然后点击 **Add webhook**。
 

--- a/content/zh/docs/project-user-guide/image-builder/binary-to-image.md
+++ b/content/zh/docs/project-user-guide/image-builder/binary-to-image.md
@@ -20,7 +20,7 @@ Binary-to-Image (B2I) 是一个工具箱和工作流，用于从二进制可执�
 | [b2i-war-java11.war](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-war-java11.war) | [springmvc5](https://github.com/kubesphere/s2i-java-container/tree/master/tomcat/examples/springmvc5) |
 | [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-binary) | [devops-go-sample](https://github.com/runzexia/devops-go-sample) |
 | [b2i-jar-java11.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java11.jar) | [ java-maven-example](https://github.com/kubesphere/s2i-java-container/tree/master/java/examples/maven) |
-| [b2i-jar-java8.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java8.jar) | [devops-java-sample](https://github.com/kubesphere/devops-java-sample) |
+| [b2i-jar-java8.jar](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-jar-java8.jar) | [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) |
 
 ## 视频演示
 

--- a/content/zh/docs/project-user-guide/image-builder/source-to-image.md
+++ b/content/zh/docs/project-user-guide/image-builder/source-to-image.md
@@ -29,7 +29,7 @@ Source-to-Image (S2I) 是一个工具箱和工作流，用于从源代码构建�
 
 ### 步骤 1：Fork 示例仓库
 
-登录 GitHub 并 Fork GitHub 仓库 [devops-java-sample](https://github.com/kubesphere/devops-java-sample) 至您的 GitHub 个人帐户。
+登录 GitHub 并 Fork GitHub 仓库 [devops-maven-sample](https://github.com/kubesphere/devops-maven-sample) 至您的 GitHub 个人帐户。
 
 ### 步骤 2：创建保密字典
 


### PR DESCRIPTION
IMO, I prefer to use https://github.com/kubesphere/devops-go-sample to replace https://github.com/yuswift/devops-go-sample.git

I have talked to @yuswift privately. There are some differences between those repositories. He will help with that.

/area devops
/cc @kubesphere/sig-devops 
/cc @kubesphere/sig-docs 

## References
* https://github.com/kubesphere/devops-go-sample/issues/1
* https://github.com/kubesphere/website/issues/2096
* https://github.com/kubesphere/ks-devops/issues/137 
* https://github.com/kubesphere/devops-maven-sample/pull/2