### PR TITLE
Revert externalElasticsearchHost to externalElasticsearchUrl

### DIFF
--- a/content/en/docs/cluster-administration/cluster-settings/log-collections/introduction.md
+++ b/content/en/docs/cluster-administration/cluster-settings/log-collections/introduction.md
@@ -45,7 +45,7 @@ To add a log receiver:
 
 A default Elasticsearch receiver will be added with its service address set to an Elasticsearch cluster if `logging`, `events`, or `auditing` is enabled in [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md).
 
-An internal Elasticsearch cluster will be deployed to the Kubernetes cluster if neither `externalElasticsearchHost` nor `externalElasticsearchPort` is specified in [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md) when `logging`, `events`, or `auditing` is enabled. The internal Elasticsearch cluster is for testing and development only. It is recommended that you configure an external Elasticsearch cluster for production.
+An internal Elasticsearch cluster will be deployed to the Kubernetes cluster if neither `externalElasticsearchUrl` nor `externalElasticsearchPort` is specified in [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md) when `logging`, `events`, or `auditing` is enabled. The internal Elasticsearch cluster is for testing and development only. It is recommended that you configure an external Elasticsearch cluster for production.
 
 Log searching relies on the internal or external Elasticsearch cluster configured.
 

--- a/content/en/docs/faq/observability/logging.md
+++ b/content/en/docs/faq/observability/logging.md
@@ -27,7 +27,7 @@ If you are using the KubeSphere internal Elasticsearch and want to change it to 
    kubectl edit cc -n kubesphere-system ks-installer
    ```
 
-2. Comment out `es.elasticsearchDataXXX`, `es.elasticsearchMasterXXX` and `status.logging`, and set `es.externalElasticsearchHost` to the address of your Elasticsearch and `es.externalElasticsearchPort` to its port number. Below is an example for your reference.
+2. Comment out `es.elasticsearchDataXXX`, `es.elasticsearchMasterXXX` and `status.logging`, and set `es.externalElasticsearchUrl` to the address of your Elasticsearch and `es.externalElasticsearchPort` to its port number. Below is an example for your reference.
 
    ```yaml
    apiVersion: installer.kubesphere.io/v1alpha1
@@ -46,7 +46,7 @@ If you are using the KubeSphere internal Elasticsearch and want to change it to 
          # elasticsearchMasterVolumeSize: 4Gi
          elkPrefix: logstash
          logMaxAge: 7
-         externalElasticsearchHost: <192.168.0.2>
+         externalElasticsearchUrl: <192.168.0.2>
          externalElasticsearchPort: <9200>
      ...
    status:

--- a/content/en/docs/installing-on-linux/introduction/air-gapped-installation.md
+++ b/content/en/docs/installing-on-linux/introduction/air-gapped-installation.md
@@ -360,7 +360,7 @@ spec:
         enabled: false
         username: ""
         password: ""
-      externalElasticsearchHost: ""
+      externalElasticsearchUrl: ""
       externalElasticsearchPort: ""
   console:
     enableMultiLogin: true

--- a/content/en/docs/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
+++ b/content/en/docs/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
@@ -454,7 +454,7 @@ spec:
       elasticsearchDataVolumeSize: 20Gi    # Volume size of Elasticsearch data nodes
       logMaxAge: 7                     # Log retention time in built-in Elasticsearch, it is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log
-      # externalElasticsearchHost:
+      # externalElasticsearchUrl:
       # externalElasticsearchPort:
   console:
     enableMultiLogin: false  # enable/disable multiple sing on, it allows a user can be used by different users at the same time.

--- a/content/en/docs/pluggable-components/auditing-logs.md
+++ b/content/en/docs/pluggable-components/auditing-logs.md
@@ -34,7 +34,7 @@ If you adopt [All-in-One Installation](../../quick-start/all-in-one-on-linux/), 
     ```
 
     {{< notice note >}}
-By default, KubeKey will install Elasticsearch internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Auditing, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, KubeKey will install Elasticsearch internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Auditing, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -45,7 +45,7 @@ By default, KubeKey will install Elasticsearch internally if Auditing is enabled
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -73,7 +73,7 @@ As you [install KubeSphere on Kubernetes](../../installing-on-kubernetes/introdu
     ```
 
     {{< notice note >}}
-By default, ks-installer will install Elasticsearch internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Auditing, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, ks-installer will install Elasticsearch internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Auditing, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -84,7 +84,7 @@ By default, ks-installer will install Elasticsearch internally if Auditing is en
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -116,7 +116,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
     ```
 
     {{< notice note >}}
-By default, Elasticsearch will be installed internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Auditing, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, Elasticsearch will be installed internally if Auditing is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Auditing, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -127,7 +127,7 @@ By default, Elasticsearch will be installed internally if Auditing is enabled. F
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 

--- a/content/en/docs/pluggable-components/events.md
+++ b/content/en/docs/pluggable-components/events.md
@@ -36,7 +36,7 @@ If you adopt [All-in-One Installation](../../quick-start/all-in-one-on-linux/), 
     ```
 
     {{< notice note >}}
-By default, KubeKey will install Elasticsearch internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Events, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, KubeKey will install Elasticsearch internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Events, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -47,7 +47,7 @@ By default, KubeKey will install Elasticsearch internally if Events is enabled. 
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -75,7 +75,7 @@ As you [install KubeSphere on Kubernetes](../../installing-on-kubernetes/introdu
     ```
 
     {{< notice note >}}
-By default, ks-installer will install Elasticsearch internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Events, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, ks-installer will install Elasticsearch internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Events, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -86,7 +86,7 @@ By default, ks-installer will install Elasticsearch internally if Events is enab
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -121,7 +121,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 
     {{< notice note >}}
 
-By default, Elasticsearch will be installed internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Events, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
+By default, Elasticsearch will be installed internally if Events is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Events, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -132,7 +132,7 @@ By default, Elasticsearch will be installed internally if Events is enabled. For
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 

--- a/content/en/docs/pluggable-components/logging.md
+++ b/content/en/docs/pluggable-components/logging.md
@@ -42,7 +42,7 @@ When you install KubeSphere on Linux, you need to create a configuration file, w
 
     {{</ notice >}}
 
-    {{< notice note >}}By default, KubeKey will install Elasticsearch internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Logging, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
+    {{< notice note >}}By default, KubeKey will install Elasticsearch internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in `config-sample.yaml` if you want to enable Logging, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, KubeKey will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -53,7 +53,7 @@ When you install KubeSphere on Linux, you need to create a configuration file, w
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -85,7 +85,7 @@ As you [install KubeSphere on Kubernetes](../../installing-on-kubernetes/introdu
 
     {{</ notice >}}
 
-    {{< notice note >}}By default, ks-installer will install Elasticsearch internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Logging, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
+    {{< notice note >}}By default, ks-installer will install Elasticsearch internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in `cluster-configuration.yaml` if you want to enable Logging, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information before installation, ks-installer will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -96,7 +96,7 @@ As you [install KubeSphere on Kubernetes](../../installing-on-kubernetes/introdu
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -134,7 +134,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 
     {{</ notice >}}
 
-    {{< notice note >}}By default, Elasticsearch will be installed internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Logging, especially `externalElasticsearchHost` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
+    {{< notice note >}}By default, Elasticsearch will be installed internally if Logging is enabled. For a production environment, it is highly recommended that you set the following values in this yaml file if you want to enable Logging, especially `externalElasticsearchUrl` and `externalElasticsearchPort`. Once you provide the following information, KubeSphere will integrate your external Elasticsearch directly instead of installing an internal one.
     {{</ notice >}}
 
     ```yaml
@@ -145,7 +145,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 

--- a/content/zh/docs/cluster-administration/cluster-settings/log-collections/introduction.md
+++ b/content/zh/docs/cluster-administration/cluster-settings/log-collections/introduction.md
@@ -45,7 +45,7 @@ KubeSphere 提供灵活的日志接收器配置方式。基于 [FluentBit Operat
 
 如果 [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md) 中启用了 `logging`、`events` 或 `auditing`，则会添加默认的 Elasticsearch 接收器，服务地址会设为 Elasticsearch 集群。
 
-当  `logging`、`events` 或 `auditing` 启用时，如果 [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md) 中未指定 `externalElasticsearchHost` 和 `externalElasticsearchPort`，则内置 Elasticsearch 集群会部署至 Kubernetes 集群。内置 Elasticsearch 集群仅用于测试和开发。生产环境下，建议您集成外置 Elasticsearch 集群。
+当  `logging`、`events` 或 `auditing` 启用时，如果 [ClusterConfiguration](https://github.com/kubesphere/kubekey/blob/release-1.1/docs/config-example.md) 中未指定 `externalElasticsearchUrl` 和 `externalElasticsearchPort`，则内置 Elasticsearch 集群会部署至 Kubernetes 集群。内置 Elasticsearch 集群仅用于测试和开发。生产环境下，建议您集成外置 Elasticsearch 集群。
 
 日志查询需要依靠所配置的内置或外置 Elasticsearch 集群。
 

--- a/content/zh/docs/faq/observability/logging.md
+++ b/content/zh/docs/faq/observability/logging.md
@@ -27,7 +27,7 @@ weight: 16310
    kubectl edit cc -n kubesphere-system ks-installer
    ```
 
-2. 将 `es.elasticsearchDataXXX`、`es.elasticsearchMasterXXX` 和 `status.logging` 的注释取消，将 `es.externalElasticsearchHost` 设置为 Elasticsearch 的地址，将 `es.externalElasticsearchPort` 设置为其端口号。以下示例供您参考：
+2. 将 `es.elasticsearchDataXXX`、`es.elasticsearchMasterXXX` 和 `status.logging` 的注释取消，将 `es.externalElasticsearchUrl` 设置为 Elasticsearch 的地址，将 `es.externalElasticsearchPort` 设置为其端口号。以下示例供您参考：
 
    ```yaml
    apiVersion: installer.kubesphere.io/v1alpha1
@@ -46,7 +46,7 @@ weight: 16310
          # elasticsearchMasterVolumeSize: 4Gi
          elkPrefix: logstash
          logMaxAge: 7
-         externalElasticsearchHost: <192.168.0.2>
+         externalElasticsearchUrl: <192.168.0.2>
          externalElasticsearchPort: <9200>
      ...
    status:

--- a/content/zh/docs/installing-on-linux/introduction/air-gapped-installation.md
+++ b/content/zh/docs/installing-on-linux/introduction/air-gapped-installation.md
@@ -355,7 +355,7 @@ spec:
         enabled: false
         username: ""
         password: ""
-      externalElasticsearchHost: ""
+      externalElasticsearchUrl: ""
       externalElasticsearchPort: ""
   console:
     enableMultiLogin: true

--- a/content/zh/docs/installing-on-linux/public-cloud/install-kubesphere-on-huaweicloud-ecs.md
+++ b/content/zh/docs/installing-on-linux/public-cloud/install-kubesphere-on-huaweicloud-ecs.md
@@ -227,7 +227,7 @@ spec:
       elasticsearchDataVolumeSize: 20Gi    # Volume size of Elasticsearch data nodes
       logMaxAge: 7                     # Log retention time in built-in Elasticsearch, it is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log
-      # externalElasticsearchHost:
+      # externalElasticsearchUrl:
       # externalElasticsearchPort:
   console:
     enableMultiLogin: false  # enable/disable multiple sing on, it allows a user can be used by different users at the same time.

--- a/content/zh/docs/pluggable-components/auditing-logs.md
+++ b/content/zh/docs/pluggable-components/auditing-logs.md
@@ -34,7 +34,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
     ```
 
     {{< notice note >}}
-默认情况下，如果启用了审计功能，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+默认情况下，如果启用了审计功能，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -45,7 +45,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -73,7 +73,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
     ```
 
     {{< notice note >}}
-默认情况下，如果启用了审计功能，ks-installer 会安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+默认情况下，如果启用了审计功能，ks-installer 会安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -84,7 +84,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -116,7 +116,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
     ```
 
     {{< notice note >}}
-默认情况下，如果启用了审计功能，将安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+默认情况下，如果启用了审计功能，将安装内置 Elasticsearch。对于生产环境，如果您想启用审计功能，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -127,7 +127,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 

--- a/content/zh/docs/pluggable-components/events.md
+++ b/content/zh/docs/pluggable-components/events.md
@@ -36,7 +36,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
     ```
 
     {{< notice note >}}
-默认情况下，如果启用了事件系统，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用事件系统，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+默认情况下，如果启用了事件系统，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用事件系统，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -47,7 +47,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -75,7 +75,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
     ```
 
     {{< notice note >}}
-对于生产环境，如果您想启用事件系统，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+对于生产环境，如果您想启用事件系统，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -86,7 +86,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -121,7 +121,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
 
     {{< notice note >}}
 
-默认情况下，如果启用了事件系统，将会安装内置 Elasticsearch。对于生产环境，如果您想启用事件系统，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在文件中提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+默认情况下，如果启用了事件系统，将会安装内置 Elasticsearch。对于生产环境，如果您想启用事件系统，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在文件中提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -132,7 +132,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 

--- a/content/zh/docs/pluggable-components/logging.md
+++ b/content/zh/docs/pluggable-components/logging.md
@@ -42,7 +42,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
 
     {{</ notice >}}
 
-    {{< notice note >}}默认情况下，如果启用了日志系统，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+    {{< notice note >}}默认情况下，如果启用了日志系统，KubeKey 将安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在 `config-sample.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，KubeKey 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -53,7 +53,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -85,7 +85,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
 
     {{</ notice >}}
 
-    {{< notice note >}}默认情况下，如果启用了日志系统，ks-installer 将安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+    {{< notice note >}}默认情况下，如果启用了日志系统，ks-installer 将安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在 `cluster-configuration.yaml` 中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在安装前提供以下信息后，ks-installer 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -96,7 +96,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 
@@ -134,7 +134,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
 
     {{</ notice >}}
 
-    {{< notice note >}}默认情况下，如果启用了日志系统，将会安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchHost` 和 `externalElasticsearchPort`。在文件中提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
+    {{< notice note >}}默认情况下，如果启用了日志系统，将会安装内置 Elasticsearch。对于生产环境，如果您想启用日志系统，强烈建议在该 YAML 文件中设置以下值，尤其是 `externalElasticsearchUrl` 和 `externalElasticsearchPort`。在文件中提供以下信息后，KubeSphere 将直接对接您的外部 Elasticsearch，不再安装内置 Elasticsearch。
     {{</ notice >}}
 
     ```yaml
@@ -145,7 +145,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
       elasticsearchDataVolumeSize: 20Gi    # The volume size of Elasticsearch data nodes.
       logMaxAge: 7                     # Log retention day in built-in Elasticsearch. It is 7 days by default.
       elkPrefix: logstash              # The string making up index names. The index name will be formatted as ks-<elk_prefix>-log.
-      externalElasticsearchHost: # The Host of external Elasticsearch.
+      externalElasticsearchUrl: # The URL of external Elasticsearch.
       externalElasticsearchPort: # The port of external Elasticsearch.
     ```
 


### PR DESCRIPTION
Signed-off-by: Felixnoo <felixliu@kubesphere.io>

/assign @kubesphere/sig-installation @kubesphere/sig-observability 

Revert the changes made in #2063.