### PR TITLE
fix: add kubectl command in the part of 'Uninstall KubeSphere Logging'

### DIFF
--- a/content/en/docs/pluggable-components/uninstall-pluggable-components.md
+++ b/content/en/docs/pluggable-components/uninstall-pluggable-components.md
@@ -97,7 +97,7 @@ Change the value of `openpitrix.store.enabled` from `true` to `false` in `ks-ins
 2. To disable only log collection:
 
    ```bash
-   delete inputs.logging.kubesphere.io -n kubesphere-logging-system tail
+   kubectl delete inputs.logging.kubesphere.io -n kubesphere-logging-system tail
    ```
 
    {{< notice note >}}

--- a/content/zh/docs/pluggable-components/uninstall-pluggable-components.md
+++ b/content/zh/docs/pluggable-components/uninstall-pluggable-components.md
@@ -98,7 +98,7 @@ kubectl -n kubesphere-system edit clusterconfiguration ks-installer
 2. 仅禁用日志收集：
 
    ```bash
-   delete inputs.logging.kubesphere.io -n kubesphere-logging-system tail
+   kubectl delete inputs.logging.kubesphere.io -n kubesphere-logging-system tail
    ```
 
    {{< notice note >}}


### PR DESCRIPTION
Description：Add kubectl command in the part of 'Uninstall KubeSphere Logging'.

Fix：#2142