### PR TITLE
Update cm devops-config instead of cc with sonarqube integration

### DIFF
--- a/content/en/docs/devops-user-guide/how-to-integrate/sonarqube.md
+++ b/content/en/docs/devops-user-guide/how-to-integrate/sonarqube.md
@@ -237,7 +237,7 @@ You need to specify `sonarqubeURL` so that you can access SonarQube directly fro
 Execute the following commands.
 
 ```bash
-kubectl -n kubesphere-system rollout restart deploy ks-apiserver
+kubectl -n kubesphere-devops-system rollout restart deploy devops-apiserver
 ```
 
 ```bash

--- a/content/zh/docs/devops-user-guide/how-to-integrate/sonarqube.md
+++ b/content/zh/docs/devops-user-guide/how-to-integrate/sonarqube.md
@@ -237,7 +237,7 @@ weight: 11310
 执行以下命令。
 
 ```bash
-kubectl -n kubesphere-system rollout restart deploy ks-apiserver
+kubectl -n kubesphere-devops-system rollout restart deploy devops-apiserver
 ```
 
 ```bash


### PR DESCRIPTION
In ks-devops v3.2, it starts to use an independent ConfigMap instead of `kubesphere-config`. Users need to change the new ConfigMap.

This PR is part of https://github.com/kubesphere/ks-devops/issues/385

/cc @kubesphere/sig-devops 