### PR TITLE
Update Documentation Link from v3.2.0 to v3.2.x

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -108,7 +108,7 @@ hasChildren = true
 
     [[languages.en.menu.main]]
     parent = "Documentation"
-    name = "v3.2.0 <img src='/images/header/star.svg' alt='star'>"
+    name = "v3.2.x <img src='/images/header/star.svg' alt='star'>"
     URL = "/docs"
     weight = 1
 
@@ -254,7 +254,7 @@ hasChildren = true
 name = "文档中心"
     [[languages.zh.menu.main]]
     parent = "文档中心"
-    name = "v3.2.0 <img src='/images/header/star.svg' alt='star'>"
+    name = "v3.2.x <img src='/images/header/star.svg' alt='star'>"
     URL = "/docs/"
     weight = 1
 


### PR DESCRIPTION
Signed-off-by: Felixnoo <felixliu@kubesphere.io>

Update documentation link according to the upcoming release of 3.2.1.
![Xnip2021-12-20_10-30-56](https://user-images.githubusercontent.com/75110798/146703662-ff7090fb-d18d-4aa5-8aa5-5d6362385dea.png)

/cc @weili520 
Please review the updates I made, thanks.