### PR TITLE
fix: Can't set background color for card title on conferences page

### DIFF
--- a/assets/scss/conferences.scss
+++ b/assets/scss/conferences.scss
@@ -15,18 +15,6 @@
 
     & > ul {
 
-      li:nth-child(1) {
-        .top-div  {
-          background-image: linear-gradient(270deg, rgb(101, 193, 148), rgb(76, 169, 134))
-        }
-      }
-
-      li:nth-child(2) {
-        .top-div  {
-          background-image: linear-gradient(to left, rgb(52, 197, 209), rgb(95, 182, 216))
-        }
-      }
-
       & > li {
         .top-div {
           position: relative;

--- a/assets/scss/content.scss
+++ b/assets/scss/content.scss
@@ -335,3 +335,7 @@
     display: none !important;
   }
 }
+
+#videoPlayer {
+  width: 100%;
+}

--- a/content/zh/conferences/_index.md
+++ b/content/zh/conferences/_index.md
@@ -9,6 +9,7 @@ list:
     content: KubeSphere 团队在 KubeCon + CloudNativeCon 2019 Shanghai 上的技术主题分享。
     icon: images/conferences/kubecon.svg
     bg: images/conferences/kubecon-bg.svg
+    bgColor: linear-gradient(270deg, rgb(101, 193, 148), rgb(76, 169, 134))
     children:
       - name: Porter-面向裸金属环境的 Kubernetes 开源负载均衡器
         summary: 我们知道，在 Kubernetes 集群中可以使用 “LoadBalancer” 类型的服务将后端工作负载暴露在外部。云厂商通常为 Kubernetes 提供云上的 LB 插件，但这需要将集群部署在特定 IaaS 平台上。然而，许多企业用户通常都将 Kubernetes…
@@ -27,11 +28,12 @@ list:
         author: 夏润泽
         link: jenkins-x/
         image: https://pek3b.qingstor.com/kubesphere-docs/png/20190930095450.png
-
+   
   - name: QCon 全球软件开发大会
     content:
     icon: images/conferences/qcon.svg
     bg: images/conferences/qcon-bg.svg
+    bgColor: linear-gradient(to left, rgb(52, 197, 209), rgb(95, 182, 216))
     children:
       - name: 基于 CSI Kubernetes 存储插件的开发实践
         summary: 现在很多用户都会将自己的应用迁移到 Kubernetes 容器平台中。在 Kubernetes 容器平台中，存储是支撑用户应用的基石。随着用户不断的将自己的应用深度部署在 K8S 容器平台中，但是我们现有的 Kubernetes…

--- a/layouts/conferences/list.html
+++ b/layouts/conferences/list.html
@@ -7,7 +7,7 @@
                 {{ $viewDetail := .Params.viewDetail }}
                 {{ range .Params.list }}
                 <li>
-                    <div class='top-div'>
+                    <div class='top-div' style="background: {{ .bgColor | safeCSS}}">
                         <img class='left-img' src="{{ .bg | relURL }}" alt="{{ .name }}">
                         <h3>{{ .name }}</h3>
                         <p>{{ .content }}</p>


### PR DESCRIPTION
### We can't set background-color for the title card on conferences page
+ screenshot:

![截屏2022-01-06 10 38 46](https://user-images.githubusercontent.com/33231138/148320020-27e28e01-44e9-4be7-b21a-acf81a01b09e.png)

+ solution:
Now, we can use the `bgColor` field to set backgorund-color for it.

### Q: How to add video on the conferences detail page

A: We can use the `<video />` label to achieve it, add it where we want in the markdown file. For example:
```
### Hello video

<video id="videoPlayer" controls="" preload="true">
  <source src="https://kubesphere-community.pek3b.qingstor.com/%E4%BA%91%E5%8E%9F%E7%94%9F%E5%AE%9E%E6%88%98/01%E3%80%81%E4%BA%91%E5%8E%9F%E7%94%9F%E5%AE%9E%E6%88%98-%E8%AF%BE%E7%A8%8B%E7%AE%80%E4%BB%8B.mp4" type="video/mp4">
</video>
```
+ Note
  - `id="videoPlayer"`、`controls=""` and `preload="true"` field is fixed and necessary
  -  The `<source></source>` label is used to add video source address, the type can be: `video/mp4`、`video/webm` and `video/ogg`
+ Example:

https://user-images.githubusercontent.com/33231138/148321958-4fd883b1-febf-4573-92f3-cb61aad7c68f.mov

