### PR TITLE
fix: Support custom year text on conferences list page

### DIFF
--- a/content/zh/conferences/_index.md
+++ b/content/zh/conferences/_index.md
@@ -6,6 +6,10 @@ viewDetail: 查看详情
 
 list:
   - name: KubeCon 大会
+    year: 
+      text:
+      color: 
+      fontSize:
     content: KubeSphere 社区在 KubeCon + CloudNativeCon 2021 上的技术主题分享。
     icon: images/conferences/kubecon.svg
     bg: images/conferences/kubecon-bg.svg

--- a/layouts/conferences/list.html
+++ b/layouts/conferences/list.html
@@ -9,7 +9,7 @@
                 <li>
                     <div class='top-div' style="background: {{ .bgColor | safeCSS}}">
                         <img class='left-img' src="{{ .bg | relURL }}" alt="{{ .name }}">
-                        <h3>{{ .name }}</h3>
+                        <h3>{{ .name }} &nbsp; <span style="color:{{ .year.color }};font-size:{{ .year.fontSize }}">{{ .year.text }}</span></h3>
                         <p>{{ .content }}</p>
                         <img class='right-img' src="{{  .icon | relURL }}" alt="{{ .name }}">
                     </div>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

+ Now, We can customize the year text by setting these fields (not required)：
  + `text`
  + `color`: text color, eg `red`.
  + `fontSize`: text size, eg:`18px`.

![截屏2022-01-18 15 19 31](https://user-images.githubusercontent.com/33231138/149890328-a977a387-81b4-4f70-a5b4-d7ca970bcfc4.png)

+ For example
  + settings:
![截屏2022-01-18 15 37 05](https://user-images.githubusercontent.com/33231138/149891624-0d8e9d1f-8064-4163-9ee1-9e0d16d5516a.png)
  + display:
![截屏2022-01-18 15 32 27](https://user-images.githubusercontent.com/33231138/149891533-97f73499-bfec-423d-89b5-3d6af5b0062e.png)

