### PR TITLE
Fix Style Issue in Deploy WordPress Doc

### DIFF
--- a/content/zh/docs/quick-start/wordpress-deployment.md
+++ b/content/zh/docs/quick-start/wordpress-deployment.md
@@ -134,8 +134,8 @@ WordPress（使用 PHP 语言编写）是免费、开源的内容管理系统，
 
 4. 通过 `{Node IP}:{NodePort}` 访问此应用程序，可以看到下图：
 
-    ![wordpress-page](/images/docs/zh-cn/quickstart/wordpress-deployment/wordpress-page.png)
+   ![wordpress-page](/images/docs/zh-cn/quickstart/wordpress-deployment/wordpress-page.png)
 
-    {{< notice note >}}
-    在访问服务之前，请确保安全组中的端口已打开。
-    {{</ notice >}}
+   {{< notice note >}}
+   在访问服务之前，请确保安全组中的端口已打开。
+   {{</ notice >}}


### PR DESCRIPTION
Signed-off-by: Felixnoo <felixliu@kubesphere.io>

/cc @Patrick-LuoYu 
Fixed a style issue in [this document](https://kubesphere.io/zh/docs/quick-start/wordpress-deployment/).

Before:
![before](https://user-images.githubusercontent.com/75110798/153169935-4a916303-a8e1-4181-b11b-8d171e2d2d19.png)

After:
![after](https://user-images.githubusercontent.com/75110798/153169965-9d41d322-95ee-4450-b9e8-a95b1bb5b304.png)

