### PR TITLE
fix-issues-2305-update-invalid-maven-cache

### DIFF
--- a/content/en/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/en/docs/devops-user-guide/examples/a-maven-project.md
@@ -45,7 +45,7 @@ The Jenkins Agent mounts the directories by Docker Volume on the node. The pipel
 The default file path of Maven settings is `maven` and the configuration file path is `/opt/apache-maven-3.5.3/conf/settings.xml`. Execute the following command to get the content of Maven settings.
 
 ```bash
-kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
+kubectl get cm -n kubesphere-devops-worker ks-devops-agent -o yaml
 ```
 
 ### Network of Maven Pod

--- a/content/zh/docs/devops-user-guide/examples/a-maven-project.md
+++ b/content/zh/docs/devops-user-guide/examples/a-maven-project.md
@@ -45,7 +45,7 @@ Jenkins Agent 通过节点上的 Docker 存储卷 (Volume) 挂载目录。流水
 Maven 设置的默认文件路径是 `maven`，配置文件路径是 `/opt/apache-maven-3.5.3/conf/settings.xml`。执行以下命令获取 Maven 的设置内容。
 
 ```bash
-kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml
+kubectl get cm -n kubesphere-devops-worker ks-devops-agent -o yaml
 ```
 
 ### Maven Pod 的网络


### PR DESCRIPTION
Fix #2305 
[Changed the namespace, the current execution command is invalid-maven-cache](https://kubesphere.io/docs/devops-user-guide/examples/a-maven-project/#maven-cache)
`kubectl get cm -n kubesphere-devops-system ks-devops-agent -o yaml`
The updated command is as follows
`kubectl get cm -n kubesphere-devops-worker ks-devops-agent -o yaml`