### PR TITLE
fix: experience account password is incorrect

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -35,7 +35,7 @@
 - id: Demo
   translation: Demo
 - id: demo content 1
-  translation: "1.Experience account: demo1 / Demo123"
+  translation: "1.Experience account: demo1 / Demo1234"
 - id: demo content 2
   translation: 2.This account is only allowed to view parts of UI
 - id: demo content 3

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -37,7 +37,7 @@
 - id: Demo
   translation: Demo
 - id: demo content 1
-  translation: "1.体验账号： demo1 / Demo123"
+  translation: "1.体验账号： demo1 / Demo1234"
 - id: demo content 2
   translation: 2.该账号仅开放了部分 UI 界面查看权限
 - id: demo content 3


### PR DESCRIPTION
The current demo environment password is no longer `Demo123`. You can log in normally with `Demo1234`
<img width="451" alt="image" src="https://user-images.githubusercontent.com/30614084/168979218-0442a95d-7ec1-4f69-8831-0ed72d343112.png">
