### PR TITLE
fix: support docs switch to the path as '/docs/v3.3'

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -25,11 +25,14 @@
 
 
 {{ if .IsDescendant (.GetPage "/docs") }}
-<link rel="stylesheet" href="/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
-{{ if not (eq . (.GetPage "/docs"))}}
-{{ $style := resources.Get "scss/doc.scss" | toCSS | minify | fingerprint }}
-<link rel="stylesheet" href="{{ $style.RelPermalink }}">
-{{ end }}
+  <link rel="stylesheet" href="/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
+  {{ if not (eq . (.GetPage "/docs"))}}
+    {{ $folder := . }}
+    {{ if not $folder.Params.isDocsRoot }}
+      {{ $style := resources.Get "scss/doc.scss" | toCSS | minify | fingerprint }}
+      <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 {{ if .IsDescendant (.GetPage "/learn") }}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

To avoid page style errors，we need to add `isDocsRoot` field for it as follow:

![截屏2022-06-23 16 01 23](https://user-images.githubusercontent.com/33231138/175251303-c8c7146a-a1e1-4395-984f-277c6fa2912b.png)

