### PR TITLE
Change kubernetes version and log view command

### DIFF
--- a/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-aks.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-aks.md
@@ -85,7 +85,7 @@ kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3
 You can inspect the logs of installation through the following command:
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Access KubeSphere Console

--- a/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-do.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-do.md
@@ -53,7 +53,7 @@ Now that the cluster is ready, you can install KubeSphere following the steps be
 - Inspect the logs of installation:
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 When the installation finishes, you can see the following message:

--- a/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-eks.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-eks.md
@@ -133,7 +133,7 @@ We will use the kubectl command-line utility for communicating with the cluster 
 - Inspect the logs of installation:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 - When the installation finishes, you can see the following message:

--- a/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-gke.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-gke.md
@@ -54,7 +54,7 @@ This guide walks you through the steps of deploying KubeSphere on [Google Kubern
 - Inspect the logs of installation:
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 - When the installation finishes, you can see the following message:

--- a/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-oke.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-oke.md
@@ -76,7 +76,7 @@ This guide walks you through the steps of deploying KubeSphere on [Oracle Kubern
 - Inspect the logs of installation:
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 - When the installation finishes, you can see the following message:

--- a/content/en/docs/v3.3/installing-on-kubernetes/introduction/overview.md
+++ b/content/en/docs/v3.3/installing-on-kubernetes/introduction/overview.md
@@ -37,7 +37,7 @@ After you make sure your existing Kubernetes cluster meets all the requirements,
 2. Inspect the logs of installation:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
 3. Use `kubectl get pod --all-namespaces` to see whether all pods are running normally in relevant namespaces of KubeSphere. If they are, check the port (30880 by default) of the console through the following command:

--- a/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/ha-configuration.md
+++ b/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/ha-configuration.md
@@ -89,10 +89,10 @@ Make `kk` executable:
 chmod +x kk
 ```
 
-Create an example configuration file with default configurations. Here Kubernetes v1.21.5 is used as an example.
+Create an example configuration file with default configurations. Here Kubernetes v1.22.10 is used as an example.
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -187,7 +187,7 @@ After you complete the configuration, you can execute the following command to s
 1. Run the following command to inspect the logs of installation.
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. When you see the following message, it means your HA cluster is successfully created.

--- a/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/internal-ha-configuration.md
+++ b/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/internal-ha-configuration.md
@@ -74,10 +74,10 @@ Make `kk` executable:
 chmod +x kk
 ```
 
-Create an example configuration file with default configurations. Here Kubernetes v1.21.5 is used as an example.
+Create an example configuration file with default configurations. Here Kubernetes v1.22.10 is used as an example.
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -170,7 +170,7 @@ After you complete the configuration, run the following command to start install
 1. Run the following command to inspect the logs of installation.
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. When you see the following message, it means your HA cluster is successfully created.

--- a/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/set-up-ha-cluster-using-keepalived-haproxy.md
+++ b/content/en/docs/v3.3/installing-on-linux/high-availability-configurations/set-up-ha-cluster-using-keepalived-haproxy.md
@@ -309,10 +309,10 @@ Make `kk` executable:
 chmod +x kk
 ```
 
-Create an example configuration file with default configurations. Here Kubernetes v1.21.5 is used as an example.
+Create an example configuration file with default configurations. Here Kubernetes v1.22.10 is used as an example.
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -386,7 +386,7 @@ After you complete the configuration, you can execute the following command to s
 1. Run the following command to inspect the logs of installation.
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. When you see the following message, it means your HA cluster is successfully created.

--- a/content/en/docs/v3.3/installing-on-linux/introduction/air-gapped-installation.md
+++ b/content/en/docs/v3.3/installing-on-linux/introduction/air-gapped-installation.md
@@ -15,7 +15,7 @@ In KubeKey v2.1.0, we bring in concepts of manifest and artifact, which provides
 
 |Host IP| Host Name | Usage      |
 | ---------------- | ---- | ---------------- |
-|192.168.0.2 | node1    | Online host for packaging the source cluster with Kubernetes v1.21.5 and KubeSphere v3.3.0 installed |
+|192.168.0.2 | node1    | Online host for packaging the source cluster with Kubernetes v1.22.10 and KubeSphere v3.3.0 installed |
 |192.168.0.3 | node2    | Control plane node of the air-gapped environment |
 |192.168.0.4 | node3    | Image registry node of the air-gapped environment |
 ## Preparations
@@ -312,7 +312,7 @@ In KubeKey v2.1.0, we bring in concepts of manifest and artifact, which provides
 2. Run the following command to create a configuration file for the air-gapped cluster:
 
    ```bash
-   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5 -f config-sample.yaml
+   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10 -f config-sample.yaml
    ```
 
 3. Run the following command to modify the configuration file:
@@ -556,7 +556,7 @@ In KubeKey v2.1.0, we bring in concepts of manifest and artifact, which provides
 8. Run the following command to view the cluster status:
 
    ```bash
-   $ kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   $ kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    After the installation is completed, the following information is displayed:

--- a/content/en/docs/v3.3/installing-on-linux/introduction/kubekey.md
+++ b/content/en/docs/v3.3/installing-on-linux/introduction/kubekey.md
@@ -85,5 +85,5 @@ If you want to use KubeKey to install both Kubernetes and KubeSphere 3.3.0, see 
 
 - You can also run `./kk version --show-supported-k8s` to see all supported Kubernetes versions that can be installed by KubeKey.
 - The Kubernetes versions that can be installed using KubeKey are different from the Kubernetes versions supported by KubeSphere v3.3.0. If you want to [install KubeSphere 3.3.0 on an existing Kubernetes cluster](../../../installing-on-kubernetes/introduction/overview/), your Kubernetes version must be v1.19.x, v1.20.x, v1.21.x, v1.22.x, and v1.23.x (experimental support).
-
+- If you want to use KubeEdge, you are advised to install Kubernetes v1.22.x or earlier to prevent compatability issues.
 {{</ notice >}}

--- a/content/en/docs/v3.3/installing-on-linux/introduction/vars.md
+++ b/content/en/docs/v3.3/installing-on-linux/introduction/vars.md
@@ -45,7 +45,7 @@ The below table describes the above parameters in detail.
    </tr>
    <tr>
      <td><code>version</code></td>
-     <td>The Kubernetes version to be installed. If you do not specify a Kubernetes version, {{< contentLink "docs/installing-on-linux/introduction/kubekey" "KubeKey" >}} v2.2.1 will install Kubernetes v1.21.5 by default. For more information, see {{< contentLink "docs/installing-on-linux/introduction/kubekey/#support-matrix" "Support Matrix" >}}.</td>
+     <td>The Kubernetes version to be installed. If you do not specify a Kubernetes version, {{< contentLink "docs/installing-on-linux/introduction/kubekey" "KubeKey" >}} v2.2.1 will install Kubernetes v1.23.7 by default. For more information, see {{< contentLink "docs/installing-on-linux/introduction/kubekey/#support-matrix" "Support Matrix" >}}.</td>
    </tr>
    <tr>
      <td><code>imageRepo</code></td>

--- a/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-and-k3s.md
+++ b/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-and-k3s.md
@@ -144,7 +144,7 @@ chmod +x kk
 4. When the installation finishes, you can inspect installation logs with the following command:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    Expected output:

--- a/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
+++ b/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
@@ -247,7 +247,7 @@ With KubeKey, you can install Kubernetes and KubeSphere together. You have the o
 Create a Kubernetes cluster with KubeSphere installed (for example, `--with-kubesphere v3.3.0`):
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}} 
@@ -299,7 +299,7 @@ Create a cluster using the configuration file you customized above:
 After the installation finishes, you can inspect the logs of installation by executing the command below:
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 If you can see the welcome log return, it means the installation is successful.

--- a/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
+++ b/content/en/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
@@ -348,7 +348,7 @@ With KubeKey, you can install Kubernetes and KubeSphere together. You have the o
 Create a Kubernetes cluster with KubeSphere installed (for example, `--with-kubesphere v3.3.0`):
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}}
@@ -506,7 +506,7 @@ Create a cluster using the configuration file you customized above:
 Inspect the logs of installation by executing the command below:
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 If you can see the welcome log return, it means the installation is successful. Your cluster is up and running.

--- a/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-glusterfs.md
+++ b/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-glusterfs.md
@@ -165,7 +165,7 @@ chmod +x kk
 1. Specify a Kubernetes version and a KubeSphere version that you want to install. For example:
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -236,7 +236,7 @@ chmod +x kk
 5. When the installation finishes, you can inspect installation logs with the following command:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    Expected output:

--- a/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-nfs-client.md
+++ b/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-nfs-client.md
@@ -117,7 +117,7 @@ chmod +x kk
 1. Specify a Kubernetes version and a KubeSphere version that you want to install. For example:
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -189,7 +189,7 @@ chmod +x kk
 7. When the installation finishes, you can inspect installation logs with the following command:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    Expected output:

--- a/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-qingcloud-csi.md
+++ b/content/en/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-qingcloud-csi.md
@@ -119,7 +119,7 @@ chmod +x kk
 1. Specify a Kubernetes version and a KubeSphere version that you want to install. For example:
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -197,7 +197,7 @@ chmod +x kk
 5. When the installation finishes, you can inspect installation logs with the following command:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    Expected output:

--- a/content/en/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-azure-vms.md
+++ b/content/en/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-azure-vms.md
@@ -142,10 +142,10 @@ The commands above download the latest release (v2.2.1) of KubeKey. You can chan
    chmod +x kk
    ```
 
-2. Create an example configuration file with default configurations. Here Kubernetes v1.21.5 is used as an example.
+2. Create an example configuration file with default configurations. Here Kubernetes v1.22.10 is used as an example.
 
    ```bash
-   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
    ```
 
    {{< notice note >}}
@@ -229,7 +229,7 @@ Azure Virtual Network doesn't support the IPIP mode used by [Calico](https://doc
 2. Inspect the logs of installation:
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 3. When the installation finishes, you can see the following message:

--- a/content/en/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-qingcloud-vms.md
+++ b/content/en/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-qingcloud-vms.md
@@ -167,10 +167,10 @@ Make `kk` executable:
 chmod +x kk
 ```
 
-Create an example configuration file with default configurations. Here Kubernetes v1.21.5 is used as an example.
+Create an example configuration file with default configurations. Here Kubernetes v1.22.10 is used as an example.
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -290,7 +290,7 @@ After you complete the configuration, you can execute the following command to s
 Inspect the logs of installation. When you see output logs as follows, it means KubeSphere has been successfully deployed.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ```bash

--- a/content/en/docs/v3.3/introduction/what's-new-in-3.3.0.md
+++ b/content/en/docs/v3.3/introduction/what's-new-in-3.3.0.md
@@ -8,6 +8,6 @@ weight: 1400
 
 In June 2022, KubeSphere 3.3.0 has been released with more exciting features. This release introduces GitOps-based continuous deployment and supports Git-based code repository management to further optimize the DevOps feature. Moreover, it also provides enhanced features of storage, multi-tenancy, multi-cluster, observability, app store, service mesh, and edge computing, to further perfect the interactive design for better user experience.
 
-If you want to know details about new feature of KubeSphere 3.3.0, you can read the article [KubeSphere 3.3.0: Embrace GitOps](https://kubesphere.com.cn/news/kubesphere-3.3.0-ga-announcement/).
+If you want to know details about new feature of KubeSphere 3.3.0, you can read the article [KubeSphere 3.3.0: Embrace GitOps](../news/kubesphere-3.3.0-ga-announcement/).
 
 In addition to the above highlights, this release also features other functionality upgrades and fixes the known bugs. There were some deprecated or removed features in 3.3.0. For more and detailed information, see the [Release Notes for 3.3.0](../../../v3.3/release/release-v330/).

--- a/content/en/docs/v3.3/multicluster-management/enable-multicluster/agent-connection.md
+++ b/content/en/docs/v3.3/multicluster-management/enable-multicluster/agent-connection.md
@@ -98,7 +98,7 @@ If you install KubeSphere on a single-node cluster ([All-in-One](../../../quick-
 You can use **kubectl** to retrieve the installation logs to verify the status by running the following command. Wait for a while, and you will be able to see the successful log return if the host cluster is ready.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Set the Proxy Service Address
@@ -252,7 +252,7 @@ If you install KubeSphere on a single-node cluster ([All-in-One](../../../quick-
 You can use **kubectl** to retrieve the installation logs to verify the status by running the following command. Wait for a while, and you will be able to see the successful log return if the member cluster is ready.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Import a Member Cluster

--- a/content/en/docs/v3.3/multicluster-management/enable-multicluster/direct-connection.md
+++ b/content/en/docs/v3.3/multicluster-management/enable-multicluster/direct-connection.md
@@ -98,7 +98,7 @@ If you install KubeSphere on a single-node cluster ([All-in-One](../../../quick-
 You can use **kubectl** to retrieve the installation logs to verify the status by running the following command. Wait for a while, and you will be able to see the successful log return if the host cluster is ready.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Prepare a Member Cluster
@@ -176,7 +176,7 @@ If you install KubeSphere on a single-node cluster ([All-in-One](../../../quick-
 You can use **kubectl** to retrieve the installation logs to verify the status by running the following command. Wait for a while, and you will be able to see the successful log return if the member cluster is ready.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Import a Member Cluster

--- a/content/en/docs/v3.3/pluggable-components/alerting.md
+++ b/content/en/docs/v3.3/pluggable-components/alerting.md
@@ -84,7 +84,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/app-store.md
+++ b/content/en/docs/v3.3/pluggable-components/app-store.md
@@ -93,7 +93,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. Use the web kubectl to check the installation process by running the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/auditing-logs.md
+++ b/content/en/docs/v3.3/pluggable-components/auditing-logs.md
@@ -134,7 +134,7 @@ By default, Elasticsearch will be installed internally if Auditing is enabled. F
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/devops.md
+++ b/content/en/docs/v3.3/pluggable-components/devops.md
@@ -90,7 +90,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. Use the web kubectl to check the installation process by running the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/events.md
+++ b/content/en/docs/v3.3/pluggable-components/events.md
@@ -139,7 +139,7 @@ By default, Elasticsearch will be installed internally if Events is enabled. For
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/kubeedge.md
+++ b/content/en/docs/v3.3/pluggable-components/kubeedge.md
@@ -138,7 +138,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 6. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/logging.md
+++ b/content/en/docs/v3.3/pluggable-components/logging.md
@@ -152,7 +152,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/metrics-server.md
+++ b/content/en/docs/v3.3/pluggable-components/metrics-server.md
@@ -89,7 +89,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/network-policy.md
+++ b/content/en/docs/v3.3/pluggable-components/network-policy.md
@@ -96,7 +96,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/pod-ip-pools.md
+++ b/content/en/docs/v3.3/pluggable-components/pod-ip-pools.md
@@ -88,7 +88,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/service-mesh.md
+++ b/content/en/docs/v3.3/pluggable-components/service-mesh.md
@@ -113,7 +113,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. Run the following command in kubectl to check the installation process:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/pluggable-components/service-topology.md
+++ b/content/en/docs/v3.3/pluggable-components/service-topology.md
@@ -88,7 +88,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of resource
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/en/docs/v3.3/quick-start/all-in-one-on-linux.md
+++ b/content/en/docs/v3.3/quick-start/all-in-one-on-linux.md
@@ -197,12 +197,12 @@ You only need to run one command for all-in-one installation. The template is as
 To create a Kubernetes cluster with KubeSphere installed, refer to the following command as an example:
 
 ```bash
-./kk create cluster --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create cluster --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}}
 
-- Recommended Kubernetes versions for KubeSphere 3.3.0: v1.19.x, v1.20.x, v1.21.x, v1.22.x, and v1.23.x (experimental support). If you do not specify a Kubernetes version, KubeKey installs Kubernetes v1.21.5 by default. For more information about supported Kubernetes versions, see [Support Matrix](../../installing-on-linux/introduction/kubekey/#support-matrix).
+- Recommended Kubernetes versions for KubeSphere 3.3.0: v1.19.x, v1.20.x, v1.21.x, v1.22.x, and v1.23.x (experimental support). If you do not specify a Kubernetes version, KubeKey installs Kubernetes v1.23.7 by default. For more information about supported Kubernetes versions, see [Support Matrix](../../installing-on-linux/introduction/kubekey/#support-matrix).
 - For all-in-one installation, you do not need to change any configuration.
 - If you do not add the flag `--with-kubesphere` in the command in this step, KubeSphere will not be deployed. KubeKey will install Kubernetes only. If you add the flag `--with-kubesphere` without specifying a KubeSphere version, the latest version of KubeSphere will be installed.
 - KubeKey will install [OpenEBS](https://openebs.io/) to provision LocalPV for the development and testing environment by default, which is convenient for new users. For other storage classes, see [Persistent Storage Configurations](../../installing-on-linux/persistent-storage-configurations/understand-persistent-storage/).
@@ -216,7 +216,7 @@ After you run the command, you will see a table for environment check. For detai
 Run the following command to check the result.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 The output displays the IP address and port number of the web console, which is exposed through `NodePort 30880` by default. Now, you can access the console at `<NodeIP>:30880` with the default account and password (`admin/P@88w0rd`).

--- a/content/en/docs/v3.3/quick-start/enable-pluggable-components.md
+++ b/content/en/docs/v3.3/quick-start/enable-pluggable-components.md
@@ -105,7 +105,7 @@ A Custom Resource Definition (CRD) allows users to create a new type of  resourc
 5. You can use the web kubectl to check the installation process by executing the following command:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice tip >}}

--- a/content/en/docs/v3.3/quick-start/minimal-kubesphere-on-k8s.md
+++ b/content/en/docs/v3.3/quick-start/minimal-kubesphere-on-k8s.md
@@ -41,7 +41,7 @@ After you make sure your machine meets the conditions, perform the following ste
 2. After KubeSphere is successfully installed, you can run the following command to view the installation logs:
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
 3. Use `kubectl get pod --all-namespaces` to see whether all Pods are running normally in relevant namespaces of KubeSphere. If they are, check the port (`30880` by default) of the console by running the following command:

--- a/content/en/docs/v3.3/upgrade/air-gapped-upgrade-with-kubekey.md
+++ b/content/en/docs/v3.3/upgrade/air-gapped-upgrade-with-kubekey.md
@@ -177,7 +177,7 @@ Execute the following command to generate an example configuration file for inst
 For example:
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f config-sample.yaml
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f config-sample.yaml
 ```
 
 {{< notice note >}}
@@ -218,7 +218,7 @@ Set `privateRegistry` of your `config-sample.yaml` file:
     privateRegistry: dockerhub.kubekey.local
 ```
 
-#### Upgrade your single-node cluster to KubeSphere 3.3.0 and Kubernetes v1.21.5
+#### Upgrade your single-node cluster to KubeSphere 3.3.0 and Kubernetes v1.22.10
 
 ```bash
 ./kk upgrade -f config-sample.yaml
@@ -242,7 +242,7 @@ To upgrade Kubernetes to a specific version, explicitly provide the version afte
 |        | Kubernetes | KubeSphere |
 | ------ | ---------- | ---------- |
 | Before | v1.18.6    | v3.2.x     |
-| After  | v1.21.5    | 3.3.0     |
+| After  | v1.22.10    | 3.3.0     |
 
 #### Upgrade a cluster
 
@@ -259,7 +259,7 @@ In this example, KubeSphere is installed on multiple nodes, so you need to speci
    For example:
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f config-sample.yaml
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f config-sample.yaml
 ```
 
 {{< notice note >}}
@@ -302,7 +302,7 @@ Set `privateRegistry` of your `config-sample.yaml` file:
     privateRegistry: dockerhub.kubekey.local
 ```
 
-#### Upgrade your multi-node cluster to KubeSphere 3.3.0 and Kubernetes v1.21.5
+#### Upgrade your multi-node cluster to KubeSphere 3.3.0 and Kubernetes v1.22.10
 
 ```bash
 ./kk upgrade -f config-sample.yaml

--- a/content/en/docs/v3.3/upgrade/upgrade-with-kubekey.md
+++ b/content/en/docs/v3.3/upgrade/upgrade-with-kubekey.md
@@ -80,10 +80,10 @@ When upgrading Kubernetes, KubeKey will upgrade from one MINOR version to the ne
 
 ### All-in-one cluster
 
-Run the following command to use KubeKey to upgrade your single-node cluster to KubeSphere 3.3.0 and Kubernetes v1.21.5:
+Run the following command to use KubeKey to upgrade your single-node cluster to KubeSphere 3.3.0 and Kubernetes v1.22.10:
 
 ```bash
-./kk upgrade --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk upgrade --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 To upgrade Kubernetes to a specific version, explicitly provide the version after the flag `--with-kubernetes`. Available versions are v1.19.x, v1.20.x, v1.21.x, v1.22.x, and v1.23.x (experimental support).
@@ -120,10 +120,10 @@ For more information, see [Edit the configuration file](../../installing-on-linu
 {{</ notice >}}
 
 #### Step 3: Upgrade your cluster
-The following command upgrades your cluster to KubeSphere 3.3.0 and Kubernetes v1.21.5:
+The following command upgrades your cluster to KubeSphere 3.3.0 and Kubernetes v1.22.10:
 
 ```bash
-./kk upgrade --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f sample.yaml
+./kk upgrade --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f sample.yaml
 ```
 
 To upgrade Kubernetes to a specific version, explicitly provide the version after the flag `--with-kubernetes`. Available versions are v1.19.x, v1.20.x, v1.21.x, v1.22.x, and v1.23.x (experimental support).

--- a/content/zh/blogs/deploying-kubesphere-clusters-offline-with-kubekey.md
+++ b/content/zh/blogs/deploying-kubesphere-clusters-offline-with-kubekey.md
@@ -280,7 +280,7 @@ $ wget https://github.com/kubesphere/kubekey/releases/download/v2.0.0-rc.3/kubek
 ### 2. 创建离线集群配置文件
 
 ```bash
-$./kk create config --with-kubesphere v3.2.1 --with-kubernetes v1.21.5 -f config-sample.yaml
+$./kk create config --with-kubesphere v3.2.1 --with-kubernetes v1.22.10 -f config-sample.yaml
 ```
 
 ### 3. 修改配置文件

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-ks-on-tencent-tke.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-ks-on-tencent-tke.md
@@ -88,7 +88,7 @@ kubectl apply -f cluster-configuration.yaml
 - 执行以下命令查看部署日志，当日志输出如以下图片内容时则表示部署完成：
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ![ks-install-log.png](/images/docs/v3.3/tencent-tke/ks-install-log.png)

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-ack.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-ack.md
@@ -183,7 +183,7 @@ kubectl apply -f cluster-configuration.yaml
 2.检查安装日志：
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 3.安装完成后，您会看到以下消息：

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-aks.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-aks.md
@@ -106,7 +106,7 @@ kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3
 可以通过以下命令检查安装日志：
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## 访问 KubeSphere 控制台

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-do.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-do.md
@@ -55,7 +55,7 @@ weight: 4230
 - 检查安装日志：
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 安装完成后，您会看到以下消息：

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-eks.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-eks.md
@@ -138,7 +138,7 @@ aws-cli/2.1.2 Python/3.7.3 Linux/4.18.0-193.6.3.el8_2.x86_64 exe/x86_64.centos.8
 - 检查安装日志：
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 - 安装完成后，您会看到以下消息：

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-gke.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-gke.md
@@ -54,7 +54,7 @@ weight: 4240
 - 检查安装日志：
 
   ```bash
-  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+  kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
   ```
 
 - 安装完成后，会看到以下消息：

--- a/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-oke.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/hosted-kubernetes/install-kubesphere-on-oke.md
@@ -72,7 +72,7 @@ weight: 4260
 2. 检查安装日志：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
 3. 安装完成后会输出以下信息：

--- a/content/zh/docs/v3.3/installing-on-kubernetes/introduction/overview.md
+++ b/content/zh/docs/v3.3/installing-on-kubernetes/introduction/overview.md
@@ -40,7 +40,7 @@ KubeSphere 承诺为用户提供即插即用架构，您可以轻松地将 KubeS
 2. 检查安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 3. 使用 `kubectl get pod --all-namespaces` 查看所有 Pod 在 KubeSphere 相关的命名空间是否正常运行。如果是正常运行，请通过以下命令来检查控制台的端口（默认为 30880）：

--- a/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/ha-configuration.md
+++ b/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/ha-configuration.md
@@ -89,10 +89,10 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 chmod +x kk
 ```
 
-创建包含默认配置的示例配置文件。这里使用 Kubernetes v1.21.5 作为示例。
+创建包含默认配置的示例配置文件。这里使用 Kubernetes v1.22.10 作为示例。
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -188,7 +188,7 @@ spec:
 1. 运行以下命令查看安装日志。
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. 若您看到以下信息，您的高可用集群便已创建成功。

--- a/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/internal-ha-configuration.md
+++ b/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/internal-ha-configuration.md
@@ -74,10 +74,10 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 chmod +x kk
 ```
 
-创建包含默认配置的示例配置文件。这里使用 Kubernetes v1.21.5 作为示例。
+创建包含默认配置的示例配置文件。这里使用 Kubernetes v1.22.10 作为示例。
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -172,7 +172,7 @@ spec:
 1. 运行以下命令查看安装日志。
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. 若您看到以下信息，您的高可用集群便已创建成功。

--- a/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/set-up-ha-cluster-using-keepalived-haproxy.md
+++ b/content/zh/docs/v3.3/installing-on-linux/high-availability-configurations/set-up-ha-cluster-using-keepalived-haproxy.md
@@ -308,10 +308,10 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 chmod +x kk
 ```
 
-使用默认配置创建一个示例配置文件。此处以 Kubernetes v1.21.5 作为示例。
+使用默认配置创建一个示例配置文件。此处以 Kubernetes v1.22.10 作为示例。
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -385,7 +385,7 @@ spec:
 1. 运行以下命令以检查安装日志。
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 2. 看到以下信息时，表明高可用集群已成功创建。

--- a/content/zh/docs/v3.3/installing-on-linux/introduction/air-gapped-installation.md
+++ b/content/zh/docs/v3.3/installing-on-linux/introduction/air-gapped-installation.md
@@ -17,7 +17,7 @@ KubeKey v2.1.0 版本新增了清单（manifest）和制品（artifact）的概�
 
 | 主机 IP   | 主机名称    | 角色            |
 | ---------------- | ----   | ---------------- |
-| 192.168.0.2 | node1    | 联网主机用于源集群打包使用。已部署 Kubernetes v1.21.5 和 KubeSphere v3.3.0 |
+| 192.168.0.2 | node1    | 联网主机用于源集群打包使用。已部署 Kubernetes v1.22.10 和 KubeSphere v3.3.0 |
 | 192.168.0.3 | node2    | 离线环境主节点 |
 | 192.168.0.4 | node3    | 离线环境镜像仓库节点 |
 
@@ -320,7 +320,7 @@ KubeKey v2.1.0 版本新增了清单（manifest）和制品（artifact）的概�
 2. 执行以下命令创建离线集群配置文件：
 
    ```bash
-   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5 -f config-sample.yaml
+   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10 -f config-sample.yaml
    ```
 
 3. 执行以下命令修改配置文件：
@@ -556,7 +556,7 @@ KubeKey v2.1.0 版本新增了清单（manifest）和制品（artifact）的概�
 8. 执行以下命令查看集群状态：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
    安装完成后，您会看到以下内容：
 

--- a/content/zh/docs/v3.3/installing-on-linux/introduction/kubekey.md
+++ b/content/zh/docs/v3.3/installing-on-linux/introduction/kubekey.md
@@ -82,10 +82,9 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 | ------------------ | ------------------------------------------------------------ |
 | v3.3.0             | v1.19.x、v1.20.x、v1.21.x、v1.22.x、v1.23.x（实验性支持） |
 
-
 {{< notice note >}} 
 
 - 您也可以运行 `./kk version --show-supported-k8s`，查看能使用 KubeKey 安装的所有受支持的 Kubernetes 版本。
 - 能使用 KubeKey 安装的 Kubernetes 版本与 KubeSphere v3.3.0 支持的 Kubernetes 版本不同。如需[在现有 Kubernetes 集群上安装 KubeSphere 3.3.0](../../../installing-on-kubernetes/introduction/overview/)，您的 Kubernetes 版本必须为 v1.19.x，v1.20.x，v1.21.x，v1.22.x 或 v1.23.x（实验性支持）。
-
+- 如果您需要使用 KubeEdge，为了避免兼容性问题，建议安装 v1.22.x 及以下版本的 Kubernetes。
 {{</ notice >}} 

--- a/content/zh/docs/v3.3/installing-on-linux/introduction/vars.md
+++ b/content/zh/docs/v3.3/installing-on-linux/introduction/vars.md
@@ -45,7 +45,7 @@ weight: 3160
    </tr>
    <tr>
      <td><code>version</code></td>
-     <td>Kubernetes 安装版本。如未指定 Kubernetes 版本，{{< contentLink "docs/installing-on-linux/introduction/kubekey" "KubeKey" >}} v2.2.1 默认安装 Kubernetes v1.21.5。有关更多信息，请参阅{{< contentLink "docs/installing-on-linux/introduction/kubekey/#support-matrix" "支持矩阵" >}}。</td>
+     <td>Kubernetes 安装版本。如未指定 Kubernetes 版本，{{< contentLink "docs/installing-on-linux/introduction/kubekey" "KubeKey" >}} v2.2.1 默认安装 Kubernetes v1.23.7。有关更多信息，请参阅{{< contentLink "docs/installing-on-linux/introduction/kubekey/#support-matrix" "支持矩阵" >}}。</td>
    </tr>
    <tr>
      <td><code>imageRepo</code></td>

--- a/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-and-k3s.md
+++ b/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-and-k3s.md
@@ -146,7 +146,7 @@ chmod +x kk
 4. 安装完成后，可运行以下命令查看安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    如果显示如下信息则安装成功：

--- a/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
+++ b/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-bare-metal.md
@@ -248,7 +248,7 @@ chmod +x kk
 创建安装有 KubeSphere 的 Kubernetes 集群（例如使用 `--with-kubesphere v3.3.0`）：
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}} 
@@ -300,7 +300,7 @@ spec:
 安装结束后，您可以执行以下命令查看安装日志：
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 如果返回欢迎日志，则安装成功。

--- a/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
+++ b/content/zh/docs/v3.3/installing-on-linux/on-premises/install-kubesphere-on-vmware-vsphere.md
@@ -338,7 +338,7 @@ chmod +x kk
 创建配置文件（一个示例配置文件）。
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}}
@@ -434,7 +434,7 @@ spec:
 此时可以看到安装日志自动输出，或者可以再打开一个 SSH 手动检查安装日志，然后等待安装成功。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 如果最后返回`Welcome to KubeSphere`，则表示已安装成功。

--- a/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-glusterfs.md
+++ b/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-glusterfs.md
@@ -165,7 +165,7 @@ chmod +x kk
 1. 指定想要安装的 Kubernetes 版本和 KubeSphere 版本，例如：
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -236,7 +236,7 @@ chmod +x kk
 5. 安装完成后，可以运行以下命令检查安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    预期输出：

--- a/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-nfs-client.md
+++ b/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-nfs-client.md
@@ -117,7 +117,7 @@ chmod +x kk
 1. 指定您想要安装的 Kubernetes 版本和 KubeSphere 版本，例如：
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -189,7 +189,7 @@ chmod +x kk
 5. 安装完成后，可以使用以下命令检查安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    预期输出：

--- a/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-qingcloud-csi.md
+++ b/content/zh/docs/v3.3/installing-on-linux/persistent-storage-configurations/install-qingcloud-csi.md
@@ -119,7 +119,7 @@ chmod +x kk
 1. 指定您想要安装的 Kubernetes 版本和 KubeSphere 版本，例如：
 
    ```bash
-   ./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+   ./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
    ```
 
    {{< notice note >}}
@@ -197,7 +197,7 @@ chmod +x kk
 5. 安装完成后，可以使用以下命令检查安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
    预期输出：

--- a/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-ali-ecs.md
+++ b/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-ali-ecs.md
@@ -141,7 +141,7 @@ chmod +x kk
 在当前位置创建配置文件 `config-sample.yaml`：
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5 -f config-sample.yaml
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10 -f config-sample.yaml
 ```
 
 > 提示：默认是 Kubernetes 1.17.9，这些 Kubernetes 版本也与 KubeSphere 同时进行过充分的测试： v1.15.12, v1.16.13, v1.17.9 (default), v1.18.6，您可以根据需要指定版本。
@@ -230,7 +230,7 @@ alibaba-cloud-csi-driver)、NFS Client、Ceph、GlusterFS，您可以根据您�
 ./kk create cluster -f config-sample.yaml
 
 # 查看 KubeSphere 安装日志  -- 直到出现控制台的访问地址和登录帐户
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ```

--- a/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-azure-vms.md
+++ b/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-azure-vms.md
@@ -145,15 +145,15 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 
 
 
-2. 使用默认配置创建示例配置文件，这里以 Kubernetes v1.21.5 为例。
+2. 使用默认配置创建示例配置文件，这里以 Kubernetes v1.22.10 为例。
 
    ```bash
-   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+   ./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
    ```
 
    {{< notice note >}}
 
-- KubeSphere 3.3.0 对应 Kubernetes 版本推荐：v1.19.x、v1.20.x、v1.21.x、 v1.22.x 和 v1.23.x（实验性支持）。如果未指定 Kubernetes 版本，KubeKey 将默认安装 Kubernetes v1.21.5。有关支持的 Kubernetes 版本请参阅[支持矩阵](../../../installing-on-linux/introduction/kubekey/#support-matrix)。
+- KubeSphere 3.3.0 对应 Kubernetes 版本推荐：v1.19.x、v1.20.x、v1.21.x、 v1.22.x 和 v1.23.x（实验性支持）。如果未指定 Kubernetes 版本，KubeKey 将默认安装 Kubernetes v1.23.7。有关支持的 Kubernetes 版本请参阅[支持矩阵](../../../installing-on-linux/introduction/kubekey/#support-matrix)。
 - 如果在此步骤中的命令中未添加标志 `--with-kubesphere`，则不会部署 KubeSphere，除非您使用配置文件中的 `addons` 字段进行安装，或稍后使用 `./kk create cluster` 时再次添加此标志。
 
 - 如果在未指定 KubeSphere 版本的情况下添加标志 --with kubesphere`，将安装 KubeSphere 的最新版本。
@@ -233,7 +233,7 @@ Azure 虚拟网络不支持 [Calico](https://docs.projectcalico.org/reference/pu
 2. 检查安装日志：
 
    ```bash
-   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+   kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
    ```
 
 3. 当安装完成，会出现如下信息：

--- a/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-huaweicloud-ecs.md
+++ b/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-huaweicloud-ecs.md
@@ -137,7 +137,7 @@ chmod +x kk
 在当前位置创建配置文件 `master-HA.yaml`：
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5 -f master-HA.yaml
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10 -f master-HA.yaml
 ```
 
 > 提示：默认是 Kubernetes 1.17.9，这些 Kubernetes 版本也与 KubeSphere 同时进行过充分的测试： v1.15.12, v1.16.13, v1.17.9 (default), v1.18.6，您可以根据需要指定版本。
@@ -283,7 +283,7 @@ spec:
  ./kk create cluster --with-kubesphere v3.3.0 -f master-HA.yaml
 
  # 查看 KubeSphere 安装日志  -- 直到出现控制台的访问地址和登录帐户
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
  ```
 
 ```

--- a/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-qingcloud-vms.md
+++ b/content/zh/docs/v3.3/installing-on-linux/public-cloud/install-kubesphere-on-qingcloud-vms.md
@@ -167,10 +167,10 @@ curl -sfL https://get-kk.kubesphere.io | VERSION=v2.2.1 sh -
 chmod +x kk
 ```
 
-创建包含默认配置的示例配置文件。以下以 Kubernetes v1.21.5 为例。
+创建包含默认配置的示例配置文件。以下以 Kubernetes v1.22.10 为例。
 
 ```bash
-./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.21.5
+./kk create config --with-kubesphere v3.3.0 --with-kubernetes v1.22.10
 ```
 
 {{< notice note >}}
@@ -289,7 +289,7 @@ spec:
 检查安装日志。如果显示如下日志，KubeSphere 安装成功。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ```bash

--- a/content/zh/docs/v3.3/introduction/what's-new-in-3.3.0.md
+++ b/content/zh/docs/v3.3/introduction/what's-new-in-3.3.0.md
@@ -8,6 +8,6 @@ weight: 1400
 
 2022 年 6 月 24 日，KubeSphere 3.3.0 正式发布，带来了更多令人期待的功能。新增了基于 GitOps 的持续部署方案，进一步优化了 DevOps 的使用体验。同时还增强了 “多集群管理、多租户管理、可观测性、应用商店、微服务治理、边缘计算、存储” 等特性，更进一步完善交互设计，并全面提升了用户体验。
 
-关于 3.3.0 新特性的详细解读，可参考博客 [KubeSphere 3.3.0 发布：全面拥抱 GitOps](https://kubesphere.com.cn/news/kubesphere-3.3.0-ga-announcement/)。
+关于 3.3.0 新特性的详细解读，可参考博客 [KubeSphere 3.3.0 发布：全面拥抱 GitOps](/zh/news/kubesphere-3.3.0-ga-announcement/)。
 
-关于 3.3.0 的新功能及增强、Bug 修复、重要的技术调整，以及废弃或移除的功能，请参见 [3.3.0 版本说明](../../v3.3/release/release-v330/)。
+关于 3.3.0 的新功能及增强、Bug 修复、重要的技术调整，以及废弃或移除的功能，请参见 [3.3.0 版本说明](../../../v3.3/release/release-v330/)。

--- a/content/zh/docs/v3.3/multicluster-management/enable-multicluster/agent-connection.md
+++ b/content/zh/docs/v3.3/multicluster-management/enable-multicluster/agent-connection.md
@@ -94,7 +94,7 @@ multicluster:
 您可以使用 **kubectl** 来获取安装日志以验证状态。运行以下命令，稍等片刻，如果主集群已准备就绪，您将看到成功的日志返回。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## 设置代理服务地址
@@ -247,7 +247,7 @@ multicluster:
 您可以使用 **kubectl** 来获取安装日志以验证状态。运行以下命令，稍等片刻，如果成员集群已准备就绪，您将看到成功的日志返回。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## 导入成员集群

--- a/content/zh/docs/v3.3/multicluster-management/enable-multicluster/direct-connection.md
+++ b/content/zh/docs/v3.3/multicluster-management/enable-multicluster/direct-connection.md
@@ -94,7 +94,7 @@ multicluster:
 您可以使用 **kubectl** 来获取安装日志以验证状态。运行以下命令，稍等片刻，如果主集群已准备就绪，您将看到成功的日志返回。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## 准备成员集群
@@ -174,7 +174,7 @@ multicluster:
 您可以使用 **kubectl** 来获取安装日志以验证状态。运行以下命令，稍等片刻，如果已准备就绪，您将看到成功的日志返回。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## 导入成员集群

--- a/content/zh/docs/v3.3/pluggable-components/alerting.md
+++ b/content/zh/docs/v3.3/pluggable-components/alerting.md
@@ -84,7 +84,7 @@ weight: 6600
 5. 在  kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/app-store.md
+++ b/content/zh/docs/v3.3/pluggable-components/app-store.md
@@ -91,7 +91,7 @@ weight: 6200
 5. 在  kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/auditing-logs.md
+++ b/content/zh/docs/v3.3/pluggable-components/auditing-logs.md
@@ -134,7 +134,7 @@ KubeSphere 审计日志系统提供了一套与安全相关并按时间顺序排
 5. 在  kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/devops.md
+++ b/content/zh/docs/v3.3/pluggable-components/devops.md
@@ -88,7 +88,7 @@ DevOps 系统为用户提供了一个自动化的环境，应用可以自动发�
 5. 在  kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/events.md
+++ b/content/zh/docs/v3.3/pluggable-components/events.md
@@ -139,7 +139,7 @@ KubeSphere 事件系统使用户能够跟踪集群内部发生的事件，例如
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/kubeedge.md
+++ b/content/zh/docs/v3.3/pluggable-components/kubeedge.md
@@ -139,7 +139,7 @@ KubeEdge 的组件在两个单独的位置运行——云上和边缘节点上�
 6. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/logging.md
+++ b/content/zh/docs/v3.3/pluggable-components/logging.md
@@ -152,7 +152,7 @@ KubeSphere 为日志收集、查询和管理提供了一个强大的、全面的
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/metrics-server.md
+++ b/content/zh/docs/v3.3/pluggable-components/metrics-server.md
@@ -90,7 +90,7 @@ KubeSphere 支持用于[部署](../../project-user-guide/application-workloads/d
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/network-policy.md
+++ b/content/zh/docs/v3.3/pluggable-components/network-policy.md
@@ -96,7 +96,7 @@ weight: 6900
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/pod-ip-pools.md
+++ b/content/zh/docs/v3.3/pluggable-components/pod-ip-pools.md
@@ -89,7 +89,7 @@ weight: 6920
 5. 在  kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/service-mesh.md
+++ b/content/zh/docs/v3.3/pluggable-components/service-mesh.md
@@ -112,7 +112,7 @@ KubeSphere 服务网格基于 [Istio](https://istio.io/)，将微服务治理和
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/pluggable-components/service-topology.md
+++ b/content/zh/docs/v3.3/pluggable-components/service-topology.md
@@ -89,7 +89,7 @@ weight: 6915
 5. 在 kubectl 中执行以下命令检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice note >}}

--- a/content/zh/docs/v3.3/quick-start/all-in-one-on-linux.md
+++ b/content/zh/docs/v3.3/quick-start/all-in-one-on-linux.md
@@ -197,7 +197,7 @@ chmod +x kk
 若要同时安装 Kubernetes 和 KubeSphere，可参考以下示例命令：
 
 ```bash
-./kk create cluster --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk create cluster --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 {{< notice note >}}
@@ -217,7 +217,7 @@ chmod +x kk
 输入以下命令以检查安装结果。
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 输出信息会显示 Web 控制台的 IP 地址和端口号，默认的 NodePort 是 `30880`。现在，您可以使用默认的帐户和密码 (`admin/P@88w0rd`) 通过 `<NodeIP>:30880` 访问控制台。

--- a/content/zh/docs/v3.3/quick-start/enable-pluggable-components.md
+++ b/content/zh/docs/v3.3/quick-start/enable-pluggable-components.md
@@ -107,7 +107,7 @@ weight: 2600
 5. 执行以下命令，使用 Web kubectl 来检查安装过程：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
     {{< notice tip >}}

--- a/content/zh/docs/v3.3/quick-start/minimal-kubesphere-on-k8s.md
+++ b/content/zh/docs/v3.3/quick-start/minimal-kubesphere-on-k8s.md
@@ -36,7 +36,7 @@ weight: 2200
 2. 检查安装日志：
 
     ```bash
-    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+    kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f
     ```
 
 3. 使用 `kubectl get pod --all-namespaces` 查看所有 Pod 是否在 KubeSphere 的相关命名空间中正常运行。如果是，请通过以下命令检查控制台的端口（默认为 `30880`）：

--- a/content/zh/docs/v3.3/upgrade/air-gapped-upgrade-with-kubekey.md
+++ b/content/zh/docs/v3.3/upgrade/air-gapped-upgrade-with-kubekey.md
@@ -177,7 +177,7 @@ chmod +x kk
 例如：
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f config-sample.yaml
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f config-sample.yaml
 ```
 
 {{< notice note >}}
@@ -218,7 +218,7 @@ chmod +x kk
     privateRegistry: dockerhub.kubekey.local
 ```
 
-#### 将单节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.21.5
+#### 将单节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.22.10
 
 ```bash
 ./kk upgrade -f config-sample.yaml
@@ -259,7 +259,7 @@ chmod +x kk
 例如：
 
 ```bash
-./kk create config --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f config-sample.yaml
+./kk create config --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f config-sample.yaml
 ```
 
 {{< notice note >}}
@@ -302,7 +302,7 @@ chmod +x kk
     privateRegistry: dockerhub.kubekey.local
 ```
 
-#### 将多节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.21.5
+#### 将多节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.22.10
 
 ```bash
 ./kk upgrade -f config-sample.yaml

--- a/content/zh/docs/v3.3/upgrade/upgrade-with-kubekey.md
+++ b/content/zh/docs/v3.3/upgrade/upgrade-with-kubekey.md
@@ -81,10 +81,10 @@ chmod +x kk
 
 ### All-in-One 集群
 
-运行以下命令使用 KubeKey 将您的单节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.21.5：
+运行以下命令使用 KubeKey 将您的单节点集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.22.10：
 
 ```bash
-./kk upgrade --with-kubernetes v1.21.5 --with-kubesphere v3.3.0
+./kk upgrade --with-kubernetes v1.22.10 --with-kubesphere v3.3.0
 ```
 
 要将 Kubernetes 升级至特定版本，请在 `--with-kubernetes` 标志后明确指定版本号。以下是可用版本：v1.19.x、v1.20.x、v1.21.x、v1.22.x 和 v1.23.x（实验性支持）。
@@ -122,10 +122,10 @@ chmod +x kk
 
 #### 步骤 3：升级集群
 
-运行以下命令，将您的集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.21.5：
+运行以下命令，将您的集群升级至 KubeSphere 3.3.0 和 Kubernetes v1.22.10：
 
 ```bash
-./kk upgrade --with-kubernetes v1.21.5 --with-kubesphere v3.3.0 -f sample.yaml
+./kk upgrade --with-kubernetes v1.22.10 --with-kubesphere v3.3.0 -f sample.yaml
 ```
 
 要将 Kubernetes 升级至特定版本，请在 `--with-kubernetes` 标志后明确指定版本号。以下是可用版本：v1.19.x、v1.20.x、v1.21.x、v1.22.x 和 v1.23.x（实验性支持）。


### PR DESCRIPTION
Signed-off-by: Bettygogo2021 <91529409+Bettygogo2021@users.noreply.github.com>
Hi, guys, pls help me review this PR and merge it. This PR mainly contains the following changes:
1. Change "--with-kubernetes v1.21.5  to --with-kubernetes v1.22.10"
2. Change the command for viewing the installation command to "kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l 'app in (ks-install, ks-installer)' -o jsonpath='{.items[0].metadata.name}') -f " as suggested.
3. Change the default Kubernetes version to 1.23.7.
/assign @Patrick-LuoYu @kubesphere/sig-installation 