### PR TITLE
fix: Algolia doesn't work in `https://v3-2.docs.kubesphere.io/docs`

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -24,7 +24,7 @@
 {{ end }}
 
 
-{{ if .IsDescendant (.GetPage "/docs") }}
+{{ if or (.IsDescendant (.GetPage "/docs")) (.InSection (.GetPage "/docs")) }}
   <link rel="stylesheet" href="/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
   {{ if not (eq . (.GetPage "/docs"))}}
     {{ $folder := . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
 <script src='{{ "js/jquery.modal.min.js" | relURL }}'></script>
 <script src='{{ "swiper/swiper-bundle.min.js" | relURL }}'></script>
 
-{{ if .IsDescendant (.GetPage "/docs") }}
+{{ if or (.IsDescendant (.GetPage "/docs")) (.InSection (.GetPage "/docs")) }}
 <script type="text/javascript" src="/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 {{ end }}
 
@@ -83,17 +83,21 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End GrowingIO Analytics code version: 2.1 -->
 
 <!-- Hotjar Tracking Code for https://kubesphere.io/docs/ -->
-{{ if (and (.Site.Params.hotjarTracking) (.IsDescendant (.GetPage "/docs")) (eq .Site.Language.Lang "en"))  }}
-<script>
-  (function(h,o,t,j,a,r){
-      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid:1756364,hjsv:6};
-      a=o.getElementsByTagName('head')[0];
-      r=o.createElement('script');r.async=1;
-      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-      a.appendChild(r);
-  })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+{{ if eq .Site.Language.Lang "en" }}
+  {{ if .Site.Params.hotjarTracking  }}
+    {{ if or (.IsDescendant (.GetPage "/docs")) (.InSection (.GetPage "/docs")) }}
+      <script>
+        (function(h,o,t,j,a,r){
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:1756364,hjsv:6};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      </script>
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

The vesion of hugo in product envirement is :`hugo v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66+extended linux/amd64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio`.

The `IsDescendant` fucntion of Page object has changed, reference here: [https://github.com/gohugoio/hugo/pull/9926](https://github.com/gohugoio/hugo/pull/9926).