### PR TITLE
fix: Update the page language logic

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,19 +8,34 @@
     const LANGUAGE_HREF = ['/', '/zh']
 
     const userLang = navigator.language;
-    const firstComeSite = !localStorage.getItem('firstVisit')
     const nowPathName = window.location.pathname
+    let cookieBanned = false
+    let pageLang
 
-    if (!!firstComeSite) {
-        localStorage.setItem('firstVisit', true)
-        const languageIndex = LANGUAGE_REG.findIndex(reg => reg.test(userLang))
+    try{
+        pageLang = localStorage.getItem('lang')
+    } catch (err){
+        cookieBanned = true
+    }
 
-        try {
-            const href_prefix = LANGUAGE_HREF[languageIndex]
-            if (!nowPathName.startsWith(href_prefix) && languageIndex !== -1) {
-                window.location.replace(href_prefix + nowPathName)
+    if(!pageLang){
+        if(userLang.indexOf('zh') !== -1){
+            pageLang = 'zh'
+        } else {
+            pageLang = 'en'
+        }
+    }
+
+    if(!cookieBanned){
+        if (pageLang === 'en') {
+            if (nowPathName.startsWith('/zh')) {
+                window.location.href =  nowPathName.slice(2,)
             }
-        } catch (err) {}
+        } else {
+            if (!nowPathName.startsWith('/zh')) {
+                window.location.href = '/zh' + nowPathName
+            }
+        }  
     }
 </script>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,7 +71,7 @@
                         {{ with .Page.AllTranslations }}
                         <ul class="dropdown-menu">
                             {{ range . }}
-                            <li onclick="location = '{{ .RelPermalink }}'">{{ .Language.LanguageName }}</li>
+                            <li onclick="handleLangClick('{{ .Language }}','{{ .RelPermalink }}')">{{ .Language.LanguageName }}</li>
                             {{ end }}
                         </ul>
                         {{ end }}
@@ -247,6 +247,10 @@ bindNavMouseEvent('.header-container .btn-li')
 
 bindClickShowMenu()
 bindClickModalLi()
-
-
+var handleLangClick = function(lang, href){
+    try{
+        localStorage.setItem('lang', lang)
+    }catch(err){}
+    location.href = href
+}
 </script>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

After the user clicks the switch page language button, the browser will store the selected language in local storage, and when the user visits the page again, the page will be displayed in that language.

If the switch page language button is not clicked, it will be displayed according to the user's browser language.