### PR TITLE
update go-get.js

### DIFF
--- a/.netlify/edge-functions/go-get.js
+++ b/.netlify/edge-functions/go-get.js
@@ -6,8 +6,8 @@ export default async (request, context) => {
     return new Response(`
 <html>
   <head>
-    <meta name="go-import" content="${url.host}${url.pathname} git https://github.com/kubesphere${url.pathname}">
-    <meta name="go-source" content="${url.host}${url.pathname} https://github.com/kubesphere${url.pathname} https://github.com/kubesphere${url.pathname}/tree/master/{/dir} https://github.com/kubesphere${url.pathname}/blob/master/{/dir}/{/file}#L{/line}">
+    <meta name="go-import" content="https://kubesphere.io${url.pathname} git https://github.com/kubesphere${url.pathname}">
+    <meta name="go-source" content="https://kubesphere.io${url.pathname} https://github.com/kubesphere${url.pathname} https://github.com/kubesphere${url.pathname}/tree/master/{/dir} https://github.com/kubesphere${url.pathname}/blob/master/{/dir}/{/file}#L{/line}">
   </head>
 </html>`)
   }


### PR DESCRIPTION


```
➜  kubesphere git:(master) ✗ go get kubesphere.io/kubesphere/client-go@latest 
go: kubesphere.io/kubesphere/client-go@latest: unrecognized import path "kubesphere.io/kubesphere/client-go": parse https://kubesphere.io/kubesphere/client-go?go-get=1: no go-import meta tags (meta tag www.kubesphere.io/kubesphere/client-go did not match import path kubesphere.io/kubesphere/client-go)
```