### PR TITLE
Optimize docs search results

### DIFF
--- a/content/en/docs/v3.3/_index.md
+++ b/content/en/docs/v3.3/_index.md
@@ -10,6 +10,7 @@ section1:
   title: KubeSphere Documentation
   content: Learn how to build and manage cloud-native applications using KubeSphere Container Platform. Get documentation, example code, tutorials, and more.
   image: /images/docs/v3.x/banner.png
+  version: "v3.3"
 
 sectionLink:
   docs:

--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -10,6 +10,7 @@ section1:
   title: KubeSphere Documentation
   content: Learn how to build and manage cloud-native applications using KubeSphere Container Platform. Get documentation, example code, tutorials, and more.
   image: /images/docs/v3.x/banner.png
+  version: "v3.4"
 
 sectionLink:
   docs:

--- a/content/zh/docs/v3.3/_index.md
+++ b/content/zh/docs/v3.3/_index.md
@@ -10,6 +10,7 @@ section1:
   title: KubeSphere 文档
   content: 了解如何通过 KubeSphere 容器平台构建并管理云原生应用程序。获取文档、示例代码与教程等信息。
   image: /images/docs/v3.x/banner.png
+  version: "v3.3"
 
 sectionLink:
   docs:

--- a/content/zh/docs/v3.4/_index.md
+++ b/content/zh/docs/v3.4/_index.md
@@ -10,6 +10,7 @@ section1:
   title: KubeSphere 文档
   content: 了解如何通过 KubeSphere 容器平台构建并管理云原生应用程序。获取文档、示例代码与教程等信息。
   image: /images/docs/v3.x/banner.png
+  version: "v3.4"
 
 sectionLink:
   docs:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,6 +16,8 @@
 <meta property="twitter:image" content="{{ with .Params.snapshot }}{{ . | absURL }}{{ else }}{{ with .Site.Params.snapshot }}{{ . | absURL }}{{ end }}{{ end }}"/>
 
 <meta name="docsearch:language" content="{{ .Site.LanguageCode }}" />
+{{ define "recursiveVersion" }}{{ if isset . "version" }}{{ .Version }}{{ else if .Params.section1.version  }}{{ .Params.section1.version }}{{ else if .Parent }}{{ template "recursiveVersion" .Parent }}{{ else }}{{ end }}{{ end }}
+<meta name="docsearch:version" content='{{ template "recursiveVersion" . }}' />
 
 <link rel="canonical" href="https://kubesphere.io{{ .RelPermalink }}" />
 

--- a/layouts/partials/searchInput.html
+++ b/layouts/partials/searchInput.html
@@ -1,5 +1,5 @@
 <div class="search-input-div">
-  <input id="search" type="text" placeholder="{{i18n "Search Documentation"}}">
+  <input id="search" type="text" placeholder="{{i18n " Search Documentation"}}">
   <svg width="1em" height="1em" viewBox="0 0 18 18">
     <g fill="none" fill-rule="evenodd">
       <path d="M12.606 11.192l5.24 5.24-1.415 1.414-5.239-5.24a7.041 7.041 0 0 0 1.414-1.414z" fill="#324558"></path>
@@ -7,34 +7,50 @@
     </g>
   </svg>
 </div>
+{{ define "recursiveVersion" }}{{ if isset . "version" }}{{ .Version }}{{ else if .Params.section1.version  }}{{ .Params.section1.version }}{{ else if .Parent }}{{ template "recursiveVersion" .Parent }}{{ else }}{{ end }}{{ end }}
 <script>
-docsearch({
-  appId:'P64S7K7Q7W',
-  apiKey: '1cf6480742e28cdc08c95710326ede25',
-  indexName: 'kubesphere',
-  inputSelector: '#search',
-  algoliaOptions: {
-      facetFilters: [`lang:${language}`],
+  docsearch({
+    appId: 'P64S7K7Q7W',
+    apiKey: '1cf6480742e28cdc08c95710326ede25',
+    indexName: 'kubesphere',
+    inputSelector: '#search',
+    algoliaOptions: {
       hitsPerPage: 10,
-  },
-  // transformData: function(hits) {
-  //   hits.forEach(hit => {
-  //     if (typeof window !== undefined) {
-  //       var host = window.location.host
-  //       if (host == 'kubesphere.com.cn') {
-  //         if (language == 'en') {
-  //           host = host + '/en'
-  //           hit.url = hit.url.replace('kubesphere.io', host)
-  //         } else if (language == 'zh') {
-  //           hit.url = hit.url.replace('kubesphere.io/zh', host)
-  //         }
-  //       } else {
-  //         hit.url = hit.url.replace('kubesphere.io', host)
-  //       }
-  //     }
-  //   })
-  //   return hits
-  // },
-  debug: false,
-})
+      facetFilters: [
+        `lang:${language}`,
+        `version:{{ template "recursiveVersion" . }}`
+      ],
+    },
+    transformData: function (hits) {
+      const releaseNoteRegex = /(releases?|notes?|patches?|updates?|changelogs?|版本|说明)/i;
+      const inputValue = document.getElementById('search').value.trim();
+      const isReleaseNote = releaseNoteRegex.test(inputValue);
+
+      if (isReleaseNote) {
+        return hits.filter(hit => hit.isReleaseNote.includes('yes'));
+      } else {
+        return hits.filter(hit => hit.isReleaseNote.includes('no'));
+      }
+    },
+    // transformData: function(hits) {
+    //   hits.forEach(hit => {
+    //     if (typeof window !== undefined) {
+    //       var host = window.location.host
+    //       if (host == 'kubesphere.com.cn') {
+    //         if (language == 'en') {
+    //           host = host + '/en'
+    //           hit.url = hit.url.replace('kubesphere.io', host)
+    //         } else if (language == 'zh') {
+    //           hit.url = hit.url.replace('kubesphere.io/zh', host)
+    //         }
+    //       } else {
+    //         hit.url = hit.url.replace('kubesphere.io', host)
+    //       }
+    //     }
+    //   })
+    //   return hits
+    // },
+    debug: false,
+  })
+
 </script>


### PR DESCRIPTION
This change resolves #3141 by only returning search queries of the current version in the current document, unless user is searching for release notes. 

This was done by adding facet filters, manipulating hits (search results), and adding version numbers to hugo templates. This change also required modifying the configuration for the algolia crawler.

Signed-off-by: Ray Zhou <rayzhou4@gmail.com>